### PR TITLE
Use pydantic for configuration tree

### DIFF
--- a/prapti/core/builtins.py
+++ b/prapti/core/builtins.py
@@ -1,6 +1,11 @@
 """
     Builtin actions.
 """
+import types
+import json
+
+import pydantic
+
 from ._core_execution_state import get_private_core_state
 from .execution_state import ExecutionState
 from .configuration import EmptyPluginConfiguration, EmptyResponderConfiguration
@@ -15,7 +20,7 @@ builtin_actions: ActionNamespace = ActionNamespace()
 # ----------------------------------------------------------------------------
 # /// DANGER -- UNDER CONSTRUCTION ///////////////////////////////////////////
 
-# plugin registry
+# plugin registry (hard coded)
 
 # HACK: right now we manually import all of the plugins and add their entry points
 # to the plugins array. in future we will want to avoid importing the module
@@ -24,15 +29,19 @@ import prapti.plugins.openai_chat_responder
 import prapti.plugins.gpt4all_chat_responder
 import prapti.plugins.experimental_gitlog
 import prapti.plugins.include
-import prapti.plugins.prapti_test_actions
 import prapti.plugins.experimental_agents
+import prapti.plugins.prapti_test_config
+import prapti.plugins.prapti_test_responder
+import prapti.plugins.prapti_test_actions
 plugins = [
     prapti.plugins.openai_chat_responder.prapti_plugin,
     prapti.plugins.gpt4all_chat_responder.prapti_plugin,
     prapti.plugins.experimental_gitlog.prapti_plugin,
     prapti.plugins.include.prapti_plugin,
+    prapti.plugins.experimental_agents.prapti_plugin,
+    prapti.plugins.prapti_test_config.prapti_plugin,
+    prapti.plugins.prapti_test_responder.prapti_plugin,
     prapti.plugins.prapti_test_actions.prapti_plugin,
-    prapti.plugins.experimental_agents.prapti_plugin
 ]
 plugins_dict = {plugin.name : plugin for plugin in plugins}
 
@@ -44,16 +53,31 @@ plugins_dict = {plugin.name : plugin for plugin in plugins}
 def load_plugin(plugin, source_loc: SourceLocation, state: ExecutionState):
     try:
         core_state = get_private_core_state(state)
-        # setup
+
         plugin_config = plugin.construct_configuration() or EmptyPluginConfiguration()
         plugin_actions: ActionNamespace = plugin.construct_actions()
         plugin_hooks = plugin.construct_hooks()
-        # commit
-        setattr(state.root_config.plugins, plugin.name, plugin_config)
+
+        path = plugin.name.split(".")
+        namespace_names, plugin_name = path[:-1], path[-1]
+
+        # navigate path to attach-point, using existing namespaces under root_config.plugins
+        config_attach_point = state.root_config.plugins
+        for name in namespace_names:
+            # if the namespace doesn't exist, create it
+            if not (new_attach_point := getattr(config_attach_point, name, None)):
+                new_attach_point = types.SimpleNamespace()
+                setattr(config_attach_point, name, new_attach_point)
+            config_attach_point = new_attach_point
+
+        setattr(config_attach_point, plugin_name, plugin_config)
+
         if plugin_actions:
             plugin_actions.set_plugin_config(plugin_config)
             core_state.actions.merge(plugin_actions)
+
         core_state.loaded_plugins.add(plugin)
+
         if plugin_hooks:
             hooks_context = hooks.HooksContext(state=state, root_config=state.root_config, plugin_config=plugin_config, hooks=plugin_hooks)
             plugin_hooks.on_plugin_loaded(hooks_context)
@@ -62,7 +86,7 @@ def load_plugin(plugin, source_loc: SourceLocation, state: ExecutionState):
         state.log.error("load-plugin-exception", f"exception while loading plugin '{plugin.name}': {repr(e)}", source_loc)
         state.log.logger.debug(e, exc_info=True)
 
-@builtin_actions.add_action("plugins.load")
+@builtin_actions.add_action("prapti.plugins.load")
 def plugins_load(name: str, raw_args: str, context: ActionContext) -> None|str|Message:
     core_state = get_private_core_state(context.state)
     global plugins, plugins_dict
@@ -71,10 +95,10 @@ def plugins_load(name: str, raw_args: str, context: ActionContext) -> None|str|M
         if plugin not in core_state.loaded_plugins:
             load_plugin(plugin, context.source_loc, context.state)
     else:
-        context.log.error("plugin-not-found", f"couldn't load plugin '{plugin_name}'. plugin not found.", context.source_loc)
+        context.log.error("plugin-not-found", f"couldn't load plugin '{plugin_name}'. plugin not found. use `%!plugins.list` to list available plugins.", context.source_loc)
     return None
 
-@builtin_actions.add_action("!plugins.list")
+@builtin_actions.add_action("!prapti.plugins.list")
 def plugins_list(name: str, raw_args: str, context: ActionContext) -> None|str|Message:
     core_state = get_private_core_state(context.state)
     global plugins
@@ -91,11 +115,11 @@ def plugins_list(name: str, raw_args: str, context: ActionContext) -> None|str|M
 
 def lookup_active_responder(state: ExecutionState) -> tuple[str, ResponderContext|None]:
     core_state = get_private_core_state(state)
-    responder_name = state.root_config.responder_stack[-1] if state.root_config.responder_stack else "default"
+    responder_name = state.root_config.prapti.responder_stack[-1] if state.root_config.prapti.responder_stack else "default"
     responder_name = core_state.hooks_distributor.on_lookup_active_responder(responder_name)
     return (responder_name, core_state.responder_contexts.get(responder_name, None))
 
-@builtin_actions.add_action("responder.new")
+@builtin_actions.add_action("prapti.responder.new")
 def responder_new(name: str, raw_args: str, context: ActionContext) -> None|str|Message:
     core_state = get_private_core_state(context.state)
     global plugins_dict
@@ -116,16 +140,89 @@ def responder_new(name: str, raw_args: str, context: ActionContext) -> None|str|
             else:
                 context.log.error("failed-responder-new", "couldn't construct responder '{responder_name}'. plugin '{plugin_name}' did not construct responder.", context.source_loc)
     else:
-        context.log.error("plugin-not-found", "couldn't locate responder provider plugin '{plugin_name}'. plugin not found.", context.source_loc)
+        context.log.error("plugin-not-found", "couldn't locate responder provider plugin '{plugin_name}'. plugin not found. use `%!plugins.list` to list available plugins.", context.source_loc)
 
-@builtin_actions.add_action("responder.push")
+@builtin_actions.add_action("prapti.responder.push")
 def responder_push(name: str, raw_args: str, context: ActionContext) -> None|str|Message:
     responder_name = raw_args.strip()
-    context.root_config.responder_stack.append(responder_name)
+    context.root_config.prapti.responder_stack.append(responder_name)
 
-@builtin_actions.add_action("responder.pop")
+@builtin_actions.add_action("prapti.responder.pop")
 def responder_pop(name: str, raw_args: str, context: ActionContext) -> None|str|Message:
-    if context.root_config.responder_stack:
-        context.root_config.responder_stack.pop()
+    if context.root_config.prapti.responder_stack:
+        context.root_config.prapti.responder_stack.pop()
 
 # ----------------------------------------------------------------------------
+# configuration inspection
+
+def _collect_leaf_configs(config_obj, accumulated_path, result) -> None:
+    if isinstance(config_obj, pydantic.BaseModel):
+        result.append((accumulated_path, config_obj))
+    else:
+        assert isinstance(config_obj, types.SimpleNamespace)
+        for field_name,field_value in config_obj.__dict__.items():
+            if field_name.startswith("_"):
+                continue
+            field_path = field_name if not accumulated_path else f"{accumulated_path}.{field_name}"
+            _collect_leaf_configs(field_value, field_path, result)
+
+def _flat_config_dump(config_obj, indent) -> str:
+    result = ""
+    leaf_configs: list[tuple[str,pydantic.BaseModel]] = []
+    _collect_leaf_configs(config_obj, "", leaf_configs)
+    print(leaf_configs)
+    for path, config in leaf_configs:
+        value_dump = _config_dump(config, indent+4)
+        if "\n" in value_dump:
+            result += f"{' '*indent}- `{path}`\n{value_dump}"
+        elif not value_dump.strip():
+            result += f"{' '*indent}- `{path}` *(no parameters)*\n"
+        else:
+            result += f"{' '*indent}- `{path} = {value_dump}`\n"
+    return result
+
+def _config_dump(config_obj, indent) -> str:
+    result = ""
+    if isinstance(config_obj, pydantic.BaseModel):
+        #if config_obj.__doc__:
+        #    result += f"{' '*indent}{config_obj.__doc__}\n"
+        for field_name, field_info in config_obj.model_fields.items():
+            if field_name.startswith("_"):
+                continue
+            field_value = getattr(config_obj, field_name)
+            field_description = "" # f" -- {field_info.description}" if field_info.description else ""
+
+            if field_name == "plugins":
+                value_dump = _flat_config_dump(field_value, indent+4)
+            else:
+                value_dump = _config_dump(field_value, indent+4)
+            if "\n" in value_dump:
+                result += f"{' '*indent}- `{field_name}`{field_description}\n{value_dump}"
+            elif not value_dump.strip():
+                result += f"{' '*indent}- `{field_name}` *(no parameters)*\n"
+            else:
+                result += f"{' '*indent}- `{field_name} = {value_dump}`{field_description}\n"
+    elif isinstance(config_obj, types.SimpleNamespace):
+        for field_name,field_value in config_obj.__dict__.items():
+            if field_name.startswith("_"):
+                continue
+            value_dump = _config_dump(field_value, indent+4)
+            if "\n" in value_dump:
+                result += f"{' '*indent}- `{field_name}`\n{value_dump}"
+            elif not value_dump.strip():
+                result += f"{' '*indent}- `{field_name}` *(no parameters)*\n"
+            else:
+                result += f"{' '*indent}- `{field_name} = {value_dump}`\n"
+    else:
+        result += json.dumps(config_obj)
+
+    return result
+
+@builtin_actions.add_action("!prapti.inspect")
+def inspect_config(name: str, raw_args: str, context: ActionContext) -> None|str|Message:
+    #core_state = get_private_core_state(context.state)
+    root_config = context.root_config
+
+    content = "Configuration parameters:\n\n" + _config_dump(root_config, indent=0)
+
+    return Message("_prapti", "inspect", [content], is_enabled=False)

--- a/prapti/core/command_interpreter.py
+++ b/prapti/core/command_interpreter.py
@@ -8,7 +8,7 @@ import re
 
 from ._core_execution_state import get_private_core_state
 from .execution_state import ExecutionState
-from .configuration import assign_configuration_field
+from .configuration import assign_field
 from .command_message import Command, Message
 from .action import Action, ActionContext
 from .source_location import SourceLocation
@@ -68,19 +68,19 @@ def _interpret_command(command_text: str, is_final_message: bool, source_loc: So
         has_exclamation = bool(match.group(1))
         name = match.group(2)
         equals_sign = match.group(3)
-        RHS = match.group(4).strip() if match.group(4) else ""
-        #state.log.debug(f"{has_exclamation = }, {name = }, {equals_sign = }, {RHS = }", source_loc)
+        rhs = match.group(4).strip() if match.group(4) else ""
+        #state.log.debug(f"{has_exclamation = }, {name = }, {equals_sign = }, {rhs = }", source_loc)
 
         if not has_exclamation or (has_exclamation and is_final_message): # has_exclamation commands only run in final message
             if equals_sign:
                 # assignment:
-                if len(RHS) == 0: # missing right hand side of assignment
+                if len(rhs) == 0: # missing right hand side of assignment
                     state.log.error("skiping-empty-assignment", f"skipping configuration assignment with no right-hand-side '{command_text}'", source_loc)
                 else:
-                    assign_configuration_field(state.root_config, name, RHS, source_loc, state.log)
+                    assign_field(state.root_config, name, rhs, source_loc, state.log)
             else:
                 # action:
-                result = run_action(has_exclamation, name, RHS, source_loc, state)
+                result = run_action(has_exclamation, name, rhs, source_loc, state)
     else:
         state.log.error("unknown-command", f"couldn't interpret command '{command_text}'", source_loc)
     return result

--- a/prapti/core/configuration.py
+++ b/prapti/core/configuration.py
@@ -121,7 +121,7 @@ def _assign_configuration_field(root_config: RootConfiguration, config_field_nam
             log.error("config-value-json-parse-error", f"could not parse configuration value '{field_value}' as JSON: {repr(e)}", source_loc)
             return
         try:
-            log.detail("set-field", f"setting configuration field: {config_field_name} = {parsed_value}", source_loc)
+            log.detail("set-field", f"setting configuration field: {config_field_name} = {json.dumps(parsed_value)}", source_loc)
             setattr(target, field_name, parsed_value) # use pydantic for coercion and validation validation
         except Exception as e:
             log.error("invalid-field-assignment", f"could not assign configuration value '{field_value}': {repr(e)}", source_loc)

--- a/prapti/core/configuration.py
+++ b/prapti/core/configuration.py
@@ -1,70 +1,137 @@
 """
-    The Configuration is a tree of dataclasses that are used to
-    configure actions, responders, hooks, plugins, etc.
+    The Configuration is a tree of namespaces with leaves that are pydantic models used to
+    store configuration parameters for actions, responders, hooks, plugins, etc.
 """
-from dataclasses import dataclass, field
+from types import SimpleNamespace
 import json
+
+from pydantic import BaseModel, Field, ConfigDict
+
 from .logger import DiagnosticsLogger
 from .source_location import SourceLocation
 
-class PluginsConfiguration:
-    """contains a dynamic configuration entry for each loaded plugin"""
-    pass
-
-class EmptyPluginConfiguration:
-    """used when the plugin provides no plugin-level configuration"""
-    pass
-
-class RespondersConfiguration:
-    """contains a dynamic configuration entry for each instantiated responder"""
-    pass
-
-class EmptyResponderConfiguration:
-    """used when the plugin provides no responder-level configuration"""
-    pass
-
-@dataclass
-class RootConfiguration:
-    """The root of the configuration tree"""
-    config_root: bool = False # halt in-tree configuration file loading when true
+class PraptiConfiguration(BaseModel):
+    """Configuration that applies to Prapti as a whole"""
+    config_root: bool = False # halt in-tree configuration file search when true
     dry_run: bool = False # simulate LLM responses. disable side-effects (plugin specific)
     strict: bool = False # fail if errors are encountered (if strict is False, errors will be reported but prapti will try to continue where ever possible)
+    responder_stack: list[str] = Field(default_factory=list)
 
-    plugins: PluginsConfiguration = field(default_factory=PluginsConfiguration)
+class PluginsConfiguration(SimpleNamespace):
+    """Configuration entries for each loaded plugin"""
 
-    responders: RespondersConfiguration = field(default_factory=RespondersConfiguration)
-    responder_stack: list[str] = field(default_factory=list)
+class EmptyPluginConfiguration(BaseModel):
+    """No plugin-level configuration parameters available"""
 
+class RespondersConfiguration(SimpleNamespace):
+    """Configuration entries for each instantiated responder"""
+
+class EmptyResponderConfiguration(BaseModel):
+    """No responder configuration parameters available"""
+
+class Vars(SimpleNamespace):
     # global/generic parameter aliases
     # if you set one of these in your markdown it will override the model-specific parameter that it aliases
-    # FIXME TODO: allow global vars to be |None or unset
-    model: str = None
-    temperature: float = None
-    n: int = None # number of responses to generate
+    # TODO: generalise, support user defined variables
+    def __init__(self):
+        super().__init__(
+            model = None, # str
+            temperature = None, # float
+            n = None) # int, number of responses to generate
 
-def assign_configuration_field(root_config: RootConfiguration, original_field_name: str, field_value: str, source_loc: SourceLocation, log: DiagnosticsLogger) -> None:
-    field_name = original_field_name
+class RootConfiguration(BaseModel):
+    """The root of the configuration tree"""
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    prapti: PraptiConfiguration = Field(default_factory=PraptiConfiguration)
+
+    plugins: PluginsConfiguration = Field(default_factory=PluginsConfiguration)
+
+    responders: RespondersConfiguration = Field(default_factory=RespondersConfiguration)
+
+    vars: Vars = Field(default_factory=Vars)
+
+def _resolve_unqualified_field_name(root_config: RootConfiguration, unqualified_field_name: str, source_loc: SourceLocation, log: DiagnosticsLogger) -> str|None:
+    # search `prapti` and `vars` namespaces. report and fail on ambiguity
+    assert "." not in unqualified_field_name
+
+    prapti_config_field = None
+    vars_field = None
+
+    if hasattr(root_config.prapti, unqualified_field_name):
+        prapti_config_field = "prapti." + unqualified_field_name
+
+    if hasattr(root_config.vars, unqualified_field_name):
+        vars_field = "vars." + unqualified_field_name
+
+    if prapti_config_field and vars_field:
+        alternatives = f"{prapti_config_field} or {vars_field}"
+        log.error("ambiguous-field-name", f"didn't perform configuration assignment. field name '{unqualified_field_name}' is ambiguous, did you mean: {alternatives}", source_loc)
+        return None
+    elif prapti_config_field:
+        resolved_field_name = prapti_config_field
+    elif vars_field:
+        resolved_field_name = vars_field
+    else:
+        # default to vars field whether or not it currently exists
+        resolved_field_name = "vars." + unqualified_field_name
+
+    log.detail(f"resolved unqualified name '{unqualified_field_name}' to '{resolved_field_name}'", source_loc)
+    return resolved_field_name
+
+def _assign_var(root_config: RootConfiguration, var_field_name: str, field_value: str, source_loc: SourceLocation, log: DiagnosticsLogger) -> None:
+    assert var_field_name.startswith("vars.")
+    var_name = var_field_name[5:] # strip off "var."
+    try:
+        parsed_value = json.loads(field_value)
+    except (ValueError, SyntaxError) as e:
+        log.error("var-value-json-parse-error", f"could not parse variable value '{field_value}' as JSON: {e}", source_loc)
+        return
+
+    log.detail("set-var", f"setting variable: {var_field_name} = {json.dumps(parsed_value)}", source_loc)
+    setattr(root_config.vars, var_name, parsed_value)
+    # TODO:
+    # - store VarEntry objects in vars namespace: VarEntry(value, is_set, last_assignment_loc)
+
+def _assign_configuration_field(root_config: RootConfiguration, config_field_name: str, field_value: str, source_loc: SourceLocation, log: DiagnosticsLogger) -> None:
+    assert not config_field_name.startswith("vars.")
+
+    # navigate '.'-separated components from `config_root`` to the `target`` object that has field `field_name``
+    field_name = config_field_name
     target = root_config
     while '.' in field_name:
         source, field_name = field_name.split('.', maxsplit=1)
         if not hasattr(target, source):
-            log.error("unknown-field-component", f"skipping configuration assignment. unknown configuration field '{original_field_name}', component '{source}' does not exist", source_loc)
+            log.error("unknown-field-component", f"didn't perform configuration assignment. unknown configuration field '{config_field_name}', component '{source}' does not exist", source_loc)
             return
         target = getattr(target, source)
 
     if hasattr(target, field_name):
+        if not isinstance(target, BaseModel):
+            log.error("internal-error-config-is-not-pydantic", f"internal error: target configuration object for `{config_field_name}` is not a pydantic BaseModel. you found a bug, please report it.")
+            return
+
         try:
             parsed_value = json.loads(field_value)
         except (ValueError, SyntaxError) as e:
-            log.error("config-value-json-parse-error", f"could not parse configuration value '{field_value}' as JSON: {e}", source_loc)
+            log.error("config-value-json-parse-error", f"could not parse configuration value '{field_value}' as JSON: {repr(e)}", source_loc)
             return
-        field_type = target.__annotations__.get(field_name)
         try:
-            assigned_value = field_type(parsed_value)
+            log.detail("set-field", f"setting configuration field: {config_field_name} = {parsed_value}", source_loc)
+            setattr(target, field_name, parsed_value) # use pydantic for coercion and validation validation
         except Exception as e:
-            log.error("config-value-coercion-failure", f"could not coerce configuration value '{field_value}' to a '{field_type}'", source_loc)
+            log.error("invalid-field-assignment", f"could not assign configuration value '{field_value}': {repr(e)}", source_loc)
             return
-        setattr(target, field_name, assigned_value)
-        log.detail("set-field", f"setting configuration field: {original_field_name} = {parsed_value}", source_loc)
     else:
-        log.error("unknown-field", f"skipping configuration assignment. unknown configuration field '{original_field_name}'", source_loc)
+        log.error("unknown-field", f"didn't assign configuration field. unknown configuration field '{config_field_name}'", source_loc)
+
+def assign_field(root_config: RootConfiguration, original_field_name: str, field_value: str, source_loc: SourceLocation, log: DiagnosticsLogger) -> None:
+    resolved_field_name = (original_field_name if "." in original_field_name
+        else _resolve_unqualified_field_name(root_config=root_config, unqualified_field_name=original_field_name, source_loc=source_loc, log=log))
+    if not resolved_field_name:
+        return
+
+    if resolved_field_name.startswith("vars."):
+        _assign_var(root_config=root_config, var_field_name=resolved_field_name, field_value=field_value, source_loc=source_loc, log=log)
+    else:
+        _assign_configuration_field(root_config=root_config, config_field_name=resolved_field_name, field_value=field_value, source_loc=source_loc, log=log)

--- a/prapti/core/configuration.py
+++ b/prapti/core/configuration.py
@@ -12,9 +12,13 @@ from .source_location import SourceLocation
 
 class PraptiConfiguration(BaseModel):
     """Configuration that applies to Prapti as a whole"""
-    config_root: bool = False # halt in-tree configuration file search when true
-    dry_run: bool = False # simulate LLM responses. disable side-effects (plugin specific)
-    strict: bool = False # fail if errors are encountered (if strict is False, errors will be reported but prapti will try to continue where ever possible)
+    model_config = ConfigDict(
+        validate_assignment=True)
+
+    config_root: bool = Field(default=False, description="Halt in-tree configuration file search once set to `true`.")
+    dry_run: bool = Field(default=False, description="Simulate LLM responses. Disable plugin-specific side effects.")
+    strict: bool = Field(default=False, description="Halt if errors are encountered. If `strict` is `false`, errors will be reported but prapti will try to continue whenever possible).")
+
     responder_stack: list[str] = Field(default_factory=list)
 
 class PluginsConfiguration(SimpleNamespace):

--- a/prapti/core/execution_state.py
+++ b/prapti/core/execution_state.py
@@ -22,3 +22,4 @@ class ExecutionState:
     selected_responder_context: ResponderContext|None = None
 
     _core_state: Any|None = None # 'CoreExecutionState'|None private to core
+    test_exfil: dict = field(default_factory=dict) # conduit for test inspection

--- a/prapti/core/source_location.py
+++ b/prapti/core/source_location.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 
-@dataclass(slots=True, frozen=True)
+@dataclass(frozen=True, slots=True)
 class SourceLocation:
     """Represent the location of an entity in a source file.
     e.g. the location of a message, command, token, etc.

--- a/prapti/core/source_location.py
+++ b/prapti/core/source_location.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True, frozen=True)
 class SourceLocation:
     """Represent the location of an entity in a source file.
     e.g. the location of a message, command, token, etc.

--- a/prapti/plugins/experimental_agents.py
+++ b/prapti/plugins/experimental_agents.py
@@ -117,7 +117,7 @@ class AgentsHooks(Hooks):
                 return name
         return None
 
-    def _find_least_recenth_discussion_group_participant(self, context: HooksContext) -> str|None:
+    def _find_least_recent_discussion_group_participant(self, context: HooksContext) -> str|None:
         if context.plugin_config.discussion_group:
             # find the least recently participating discussion participant and give them a turn
             # return an arbitrary element if not all participants have sent a message
@@ -134,7 +134,7 @@ class AgentsHooks(Hooks):
     def _select_agent(self, context: HooksContext) -> str|None:
         if pending_at_mentions := self._compute_pending_at_mentions(context):
             return self._pop_valid_pending_at_mention(pending_at_mentions, context)
-        return self._find_least_recenth_discussion_group_participant(context)
+        return self._find_least_recent_discussion_group_participant(context)
 
     def on_lookup_active_responder(self, responder_name: str, context: HooksContext) -> str:
         return self._select_agent(context) or responder_name
@@ -190,7 +190,7 @@ class AgentsHooks(Hooks):
 
     def on_followup(self, context: HooksContext) -> tuple[bool, list[Message]|None]:
         if context.plugin_config.discussion_group and context.plugin_config.remaining_discussion_message_count > 0:
-            if agent_name := self._find_least_recenth_discussion_group_participant(context):
+            if agent_name := self._find_least_recent_discussion_group_participant(context):
                 # trigger the agent by @-mentioning them. This will be picked up in on_before_generate_responses
                 # this hopefully ensures that all participants get a turn even if they are also @-messaging each other
                 return True, [Message(role="_prapti.experimental.agents", name=None, content=[f"@{agent_name}"])]

--- a/prapti/plugins/experimental_gitlog.py
+++ b/prapti/plugins/experimental_gitlog.py
@@ -155,7 +155,7 @@ class GitlogHooks(Hooks):
             # the file has no hashes, it has never been comitted. add it
             branch_name = make_branch_name(file_path)
             log.debug(f"gitlog: adding file {file_path.name} on new branch {branch_name}")
-            if not context.root_config.dry_run:
+            if not context.root_config.prapti.dry_run:
                 run_command(f"git checkout --orphan {branch_name}", shadow_worktree_dir, log)
 
                 shadow_file_name = shadow_worktree_dir/file_path.name
@@ -175,7 +175,7 @@ class GitlogHooks(Hooks):
             # the prefix is the current tip, the input is append-only, no need to branch
             log.debug("gitlog: comitting modifications to current branch")
 
-            if not context.root_config.dry_run:
+            if not context.root_config.prapti.dry_run:
                 run_command(f"git commit -a -m '{commit_message}'", main_worktree_dir, log)
             else:
                 log.debug("gitlog: dry run. no action taken")
@@ -183,7 +183,7 @@ class GitlogHooks(Hooks):
             # back-track and branch
             branch_name = make_branch_name(file_path)
             log.debug(f"backtracking to {potential_branch_point.hash} and comitting modifications on new branch {branch_name}")
-            if not context.root_config.dry_run:
+            if not context.root_config.prapti.dry_run:
                 # create a branch at potential_branch_point.hash while leaving our input file unmodified
                 # without geting errors about there being uncomitted changes
 
@@ -220,7 +220,7 @@ class GitlogHooks(Hooks):
         main_worktree_dir = context.state.input_file_path.resolve().parent
         log.debug(f"{context.state.input_file_path.name = }, {main_worktree_dir = }")
 
-        if not context.root_config.dry_run:
+        if not context.root_config.prapti.dry_run:
             run_command(f"git commit -a -m 'assistant response'", main_worktree_dir, log)
         log.debug("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
 

--- a/prapti/plugins/prapti_test_actions.md
+++ b/prapti/plugins/prapti_test_actions.md
@@ -1,4 +1,4 @@
-%plugins.load prapti.test.actions
+%plugins.load prapti.test.test_actions
 
 % temperature = 0.2
 % model = "gpt-3.5-turbo"

--- a/prapti/plugins/prapti_test_actions.py
+++ b/prapti/plugins/prapti_test_actions.py
@@ -28,7 +28,7 @@ class TestActionsPlugin(Plugin):
     def __init__(self):
         super().__init__(
             api_version = "0.1.0",
-            name = "prapti.test.actions",
+            name = "prapti.test.test_actions",
             version = "0.0.1",
             description = "Actions used to test Prapti"
         )

--- a/prapti/plugins/prapti_test_config.py
+++ b/prapti/plugins/prapti_test_config.py
@@ -1,0 +1,31 @@
+"""
+    test plugin with non-empty config
+"""
+import typing
+from pydantic import BaseModel, Field, ConfigDict
+from ..core.plugin import Plugin
+
+class TestConfigConfiguration(BaseModel):
+    """Configuration parameters for the prapti.test.test_config plugin"""
+    model_config = ConfigDict(
+        validate_assignment=True)
+
+    a_bool: bool = False
+    an_int: int = 0
+    a_float: float = 0.0
+    a_string: str = "test"
+    a_list_of_strings: list[str] = Field(default_factory=list)
+
+class TestConfigPlugin(Plugin):
+    def __init__(self):
+        super().__init__(
+            api_version = "0.1.0",
+            name = "prapti.test.test_config",
+            version = "0.0.1",
+            description = "Plugin used to test Prapti"
+        )
+
+    def construct_configuration(self) -> typing.Any|None:
+        return TestConfigConfiguration()
+
+prapti_plugin = TestConfigPlugin()

--- a/prapti/plugins/prapti_test_responder.py
+++ b/prapti/plugins/prapti_test_responder.py
@@ -1,0 +1,60 @@
+"""
+    Test responder plugin
+"""
+import typing
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..core.plugin import Plugin
+from ..core.command_message import Message
+from ..core.responder import Responder, ResponderContext
+
+class TestResponderConfiguration(BaseModel):
+    """Configuration parameters for test responder."""
+    model_config = ConfigDict(
+        validate_assignment=True)
+
+    a_bool: bool = False
+    an_int: int = 0
+    a_float: float = 0.0
+    a_string: str = "test"
+    a_list_of_strings: list[str] = Field(default_factory=list)
+
+    temperature: int = 1 # used to test late-bound vars
+    model: str = "test"
+    n: int = 1
+
+class TestResponder(Responder):
+    def __init__(self):
+        super().__init__()
+
+    def construct_configuration(self, context: ResponderContext) -> typing.Any|None:
+        return TestResponderConfiguration()
+
+    def generate_responses(self, input_: list[Message], context: ResponderContext) -> list[Message]:
+        config: TestResponderConfiguration = context.responder_config
+        context.log.debug(f"prapti.test.test_responder: {config = }", context.state.input_file_path)
+
+        # propagate late-bound global variables:
+        for name in ("model", "temperature", "n"):
+            if (value := getattr(context.root_config.vars, name, None)) is not None:
+                context.log.debug(f"openai.chat: binding config.{name} <- {value} from vars.{name}", context.state.input_file_path)
+                setattr(config, name, value)
+
+        context.state.test_exfil["test_responder_resolved_config"] = config
+
+        return [Message(role="assistant", name=None, content=["Test!"])]
+
+class TestResponderPlugin(Plugin):
+    def __init__(self):
+        super().__init__(
+            api_version = "0.1.0",
+            name = "prapti.test.test_responder",
+            version = "0.0.1",
+            description = "Test responder"
+        )
+
+    def construct_responder(self) -> Responder|None:
+        return TestResponder()
+
+prapti_plugin = TestResponderPlugin()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Topic :: Text Processing :: Markup :: Markdown"
 ]
 dependencies = [
+    "pydantic >= 2.0.2",
     "openai >= 0.27.6",
     "tiktoken >= 0.4.0",
     "gpt4all >= 1.0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Topic :: Text Processing :: Markup :: Markdown"
 ]
 dependencies = [
-    "pydantic >= 2.0.2",
+    "pydantic >= 2.1.1",
     "openai >= 0.27.6",
     "tiktoken >= 0.4.0",
     "gpt4all >= 1.0.2"
@@ -63,3 +63,4 @@ testpaths = [
 addopts = [
     "--import-mode=importlib",
 ]
+python_classes = "!Test"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,234 @@
+import pydantic
+from prapti.core.execution_state import ExecutionState
+from prapti.plugins.prapti_test_config import TestConfigConfiguration
+from prapti.plugins.prapti_test_responder import TestResponderConfiguration
+
+LOAD_PlUGIN_PROMPT = """\
+% plugins.load prapti.test.test_config
+### @user:
+
+Hello
+"""
+def test_load_plugin(tmp_path, monkeypatch):
+    """Test loading a plugin"""
+    temp_md_path = tmp_path / "test_load_plugin_temp.md"
+    temp_md_path.write_text(LOAD_PlUGIN_PROMPT, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", str(temp_md_path)])
+
+    import prapti.tool
+    test_exfil = {}
+    exit_status = prapti.tool.main(test_exfil=test_exfil)
+    assert exit_status == 0
+
+    state: ExecutionState = test_exfil["state"]
+    # test that plugin config was created in the expected location in the config tree:
+    config: TestConfigConfiguration = state.root_config.plugins.prapti.test.test_config
+    assert isinstance(config, pydantic.BaseModel)
+    # check initial values
+    assert config.a_bool == False
+    assert config.an_int == 0
+    assert config.a_float == 0.0
+    assert config.a_string == "test"
+    assert config.a_list_of_strings == []
+
+SET_PLUGIN_CONFIG_FIELDS_PROMPT = """\
+% plugins.load prapti.test.test_config
+% plugins.prapti.test.test_config.a_bool = true
+% plugins.prapti.test.test_config.an_int = 42
+% plugins.prapti.test.test_config.a_float = 0.5
+% plugins.prapti.test.test_config.a_string = "hello"
+% plugins.prapti.test.test_config.a_list_of_strings = ["one", "two", "three"]
+### @user:
+
+Hello
+"""
+def test_set_plugin_config_fields(tmp_path, monkeypatch):
+    """Test setting plugin config fields from markdown"""
+    temp_md_path = tmp_path / "test_set_plugin_config_fields_temp.md"
+    temp_md_path.write_text(SET_PLUGIN_CONFIG_FIELDS_PROMPT, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", str(temp_md_path)])
+
+    import prapti.tool
+    test_exfil = {}
+    exit_status = prapti.tool.main(test_exfil=test_exfil)
+    assert exit_status == 0
+
+    state: ExecutionState = test_exfil["state"]
+    config: TestConfigConfiguration = state.root_config.plugins.prapti.test.test_config
+    # check values set in the markdown file:
+    assert config.a_bool == True
+    assert config.an_int == 42
+    assert config.a_float == 0.5
+    assert config.a_string == "hello"
+    assert config.a_list_of_strings == ["one", "two", "three"]
+
+NEW_RESPONDER_PROMPT = """\
+% plugins.load prapti.test.test_responder
+% responder.new default prapti.test.test_responder
+### @user:
+
+Hello
+"""
+def test_new_responder(tmp_path, monkeypatch):
+    """Test creating a responder"""
+    temp_md_path = tmp_path / "test_new_responder_temp.md"
+    temp_md_path.write_text(NEW_RESPONDER_PROMPT, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", "--no-default-config", str(temp_md_path)])
+
+    import prapti.tool
+    test_exfil = {}
+    exit_status = prapti.tool.main(test_exfil=test_exfil)
+    assert exit_status == 0
+
+    state: ExecutionState = test_exfil["state"]
+    # test that plugin config was created in the expected location in the config tree:
+    config: TestResponderConfiguration = state.root_config.responders.default
+    # check initial values
+    assert config.a_bool == False
+    assert config.an_int == 0
+    assert config.a_float == 0.0
+    assert config.a_string == "test"
+    assert config.a_list_of_strings == []
+
+TEST_SET_RESPONDER_CONFIG_FIELDS_PROMPT = """\
+% plugins.load prapti.test.test_responder
+% responder.new default prapti.test.test_responder
+% responders.default.a_bool = true
+% responders.default.an_int = 42
+% responders.default.a_float = 0.5
+% responders.default.a_string = "hello"
+% responders.default.a_list_of_strings = ["one", "two", "three"]
+### @user:
+
+Hello
+"""
+def test_set_responder_config_fields(tmp_path, monkeypatch):
+    """Test setting responder config fields from markdown"""
+    temp_md_path = tmp_path / "test_set_plugin_config_fields_temp.md"
+    temp_md_path.write_text(TEST_SET_RESPONDER_CONFIG_FIELDS_PROMPT, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", "--no-default-config", str(temp_md_path)])
+
+    import prapti.tool
+    test_exfil = {}
+    exit_status = prapti.tool.main(test_exfil=test_exfil)
+    assert exit_status == 0
+
+    state: ExecutionState = test_exfil["state"]
+    config: TestResponderConfiguration = state.root_config.responders.default
+    # check values set in the markdown file
+    assert config.a_bool == True
+    assert config.an_int == 42
+    assert config.a_float == 0.5
+    assert config.a_string == "hello"
+    assert config.a_list_of_strings == ["one", "two", "three"]
+
+TEST_SET_LATE_BOUND_VARS_PROMPT = """\
+% plugins.load prapti.test.test_responder
+% responder.new default prapti.test.test_responder
+% vars.temperature = 100
+% model = "test model"
+% vars.n = 101
+### @user:
+
+Hello
+"""
+# ^^^ tests both qualified (vars.) and unqualified variable assignment
+def test_set_late_bound_vars(tmp_path, monkeypatch):
+    """Test setting a late bound vars and checking that they are used in responder"""
+    temp_md_path = tmp_path / "test_set_late_bound_vars_temp.md"
+    temp_md_path.write_text(TEST_SET_LATE_BOUND_VARS_PROMPT, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", "--no-default-config", str(temp_md_path)])
+
+    import prapti.tool
+    test_exfil = {}
+    exit_status = prapti.tool.main(test_exfil=test_exfil)
+    assert exit_status == 0
+
+    resolved_config: TestResponderConfiguration = test_exfil["test_responder_resolved_config"]
+    # check values set in the markdown file
+    assert resolved_config.temperature == 100
+    assert resolved_config.model == "test model"
+    assert resolved_config.n == 101
+
+def collect_logged_message_ids(caplog):
+    message_ids = set()
+    for record in caplog.records:
+        if getattr(record, "message_id", None):
+            message_ids.add(record.message_id)
+    return message_ids
+
+# NOTE: in the tests below, load a default responder so we don't get false-positive failures
+# due to "no default responder" errors.
+
+TEST_SET_FIELD_OF_NONEXISTANT_PLUGIN = """\
+% plugins.load prapti.test.test_responder
+% responder.new default prapti.test.test_responder
+% plugins.nonexistant.alsononexistant.x = 100
+### @user:
+
+Hello
+"""
+def test_set_field_of_nonexistant_plugin(tmp_path, monkeypatch, caplog):
+    """Test that we get an error when setting a field of a non-existant plugin"""
+    temp_md_path = tmp_path / "test_set_field_of_nonexistant_plugin_temp.md"
+    temp_md_path.write_text(TEST_SET_FIELD_OF_NONEXISTANT_PLUGIN, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", "--no-default-config", str(temp_md_path)])
+
+    import prapti.tool
+    exit_status = prapti.tool.main()
+    assert exit_status != 0 # expect failure
+
+    message_ids = collect_logged_message_ids(caplog)
+    assert "unknown-field-component" in message_ids
+
+TEST_SET_NONEXISTANT_PLUGIN_FIELD = """\
+% plugins.load prapti.test.test_responder
+% responder.new default prapti.test.test_responder
+% plugins.load prapti.test.test_config
+% plugins.prapti.test.test_config.nonexistant = 100
+### @user:
+
+Hello
+"""
+def test_set_nonexistant_plugin_field(tmp_path, monkeypatch, caplog):
+    """Test that we get an error when setting a non-existant field of plugin configuration"""
+    temp_md_path = tmp_path / "test_set_nonexistant_plugin_field_temp.md"
+    temp_md_path.write_text(TEST_SET_NONEXISTANT_PLUGIN_FIELD, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", "--no-default-config", str(temp_md_path)])
+
+    import prapti.tool
+    exit_status = prapti.tool.main()
+    assert exit_status != 0 # expect failure
+
+    message_ids = collect_logged_message_ids(caplog)
+    assert "unknown-field" in message_ids
+
+TEST_SET_PLUGIN_FIELD_WITH_INVALID_VALUE = """\
+% plugins.load prapti.test.test_responder
+% responder.new default prapti.test.test_responder
+% plugins.load prapti.test.test_config
+% plugins.prapti.test.test_config.an_int = "test"
+### @user:
+
+Hello
+"""
+def test_set_plugin_field_with_invalid_value(tmp_path, monkeypatch, caplog):
+    """Test that we get a validation error when setting a field to an invalid value (assign non-numeric string to int field)"""
+    temp_md_path = tmp_path / "test_set_plugin_field_with_invalid_value_temp.md"
+    temp_md_path.write_text(TEST_SET_PLUGIN_FIELD_WITH_INVALID_VALUE, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", "--no-default-config", str(temp_md_path)])
+
+    import prapti.tool
+    exit_status = prapti.tool.main()
+    assert exit_status != 0 # expect failure
+
+    message_ids = collect_logged_message_ids(caplog)
+    assert "invalid-field-assignment" in message_ids

--- a/tests/test_source_location.py
+++ b/tests/test_source_location.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from prapti.core.source_location import SourceLocation
+
+from pydantic import BaseModel, ConfigDict
+
+class Foo(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    bar : int = 1
+    #source_loc : SourceLocation|None = None
+
+def test_source_location():
+    foo = Foo()
+
+    file_path = Path("test/path")
+
+    source_loc = SourceLocation()
+    assert source_loc.file_path is None
+    assert source_loc.line is None
+    assert source_loc.column is None
+
+    source_loc = SourceLocation(file_path=file_path)
+    assert source_loc.file_path == file_path
+    assert source_loc.line is None
+    assert source_loc.column is None
+
+    source_loc = SourceLocation(file_path=file_path, line=42)
+    assert source_loc.file_path == file_path
+    assert source_loc.line == 42
+    assert source_loc.column is None
+
+    source_loc = SourceLocation(file_path=file_path, line=42, column=101)
+    assert source_loc.file_path == file_path
+    assert source_loc.line == 42
+    assert source_loc.column == 101
+

--- a/tests/test_source_location.py
+++ b/tests/test_source_location.py
@@ -1,16 +1,7 @@
 from pathlib import Path
 from prapti.core.source_location import SourceLocation
 
-from pydantic import BaseModel, ConfigDict
-
-class Foo(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-    bar : int = 1
-    #source_loc : SourceLocation|None = None
-
 def test_source_location():
-    foo = Foo()
-
     file_path = Path("test/path")
 
     source_loc = SourceLocation()
@@ -32,4 +23,3 @@ def test_source_location():
     assert source_loc.file_path == file_path
     assert source_loc.line == 42
     assert source_loc.column == 101
-


### PR DESCRIPTION
- replace dataclasses with pydantic BaseModels for configuration structures
- move global configuration fields to `prapti` and `vars` namespaces
- first cut of `%!prapti.inspect` action
- instantiate plugins into nested SimpleNamespaces
- move some experimental.agents state out of the plugin's configuration class
    
    
    
    