### PR TITLE
support loading user config from $XDG_CONFIG_HOME/prapti/config.md etc.

### DIFF
--- a/docs/config_files.md
+++ b/docs/config_files.md
@@ -6,7 +6,7 @@ Prapti uses configuration files to store setup details and parameter settings. T
 
 Before processing the input markdown file, Prapti searches for configuration files. The search process includes:
 
-1. Loading a user configuration file from the user's home directory, if such a file exists. Locations that are searched are: `$XDG_CONFIG_HOME/prapti/config.md`, `~/.config/prapti/config.md`, and `~/.prapti/config.md`. Only the first user configuration file that is found is loaded. If the `$XDG_CONFIG_HOME` environment variable is set, only the first path is included in the search.
+1. Loading a user configuration file from the user's home directory, if such a file exists. The following locations are searched: `$XDG_CONFIG_HOME/prapti/config.md`, `~/.config/prapti/config.md`, and `~/.prapti/config.md`. Only the first user configuration file that is found is loaded. If the `$XDG_CONFIG_HOME` environment variable is set, only the first location is included in the search.
 2. Searching for `.prapticonfig.md` files in the directory of the input markdown file and its parent directories. This search continues upwards until a configuration file with a line `% config_root = true` is found. These files form the in-tree configuration file set.
 3. Loading the in-tree configuration files, starting from the root and moving towards the input file's directory. This way, settings in `.prapticonfig.md` files closer to the input file take precedence over settings from files closer to the root.
 

--- a/docs/config_files.md
+++ b/docs/config_files.md
@@ -1,12 +1,12 @@
 # Prapti Configuration Files
 
-Prapti uses configuration files to store setup details and parameter settings. These files are regular Prapti markdown files loaded before the input markdown file. If no configuration files are found, Prapti uses an internal fallback configuration.
+Prapti uses configuration files to store setup details and parameter settings. These files are regular Prapti markdown files that are loaded before the input markdown file. If no configuration files are found, Prapti uses an internal fallback configuration.
 
 ## Default Configuration File Search
 
 Before processing the input markdown file, Prapti searches for configuration files. The search process includes:
 
-1. Loading a user configuration file from the user's home directory (e.g., `~/.prapti/config.md`) if it exists.
+1. Loading a user configuration file from the user's home directory, if such a file exists. Locations that are searched are: `$XDG_CONFIG_HOME/prapti/config.md`, `~/.config/prapti/config.md`, and `~/.prapti/config.md`. Only the first user configuration file that is found is loaded. If the `$XDG_CONFIG_HOME` environment variable is set, only the first path is included in the search.
 2. Searching for `.prapticonfig.md` files in the directory of the input markdown file and its parent directories. This search continues upwards until a configuration file with a line `% config_root = true` is found. These files form the in-tree configuration file set.
 3. Loading the in-tree configuration files, starting from the root and moving towards the input file's directory. This way, settings in `.prapticonfig.md` files closer to the input file take precedence over settings from files closer to the root.
 
@@ -25,7 +25,7 @@ Any supplied configuration file should contain this or an equivalent set-up.
 
 The `--no-default-config` command line option disables the default configuration file search and the fallback configuration. This is useful for providing a different configuration file or working in isolation in the input markdown file.
 
-## Specifying Configuration Files
+## Specifying Additional Configuration Files
 
 The `--config-file` command line option specifies one or more configuration files. These files are loaded after any default configuration files. If multiple configuration files are supplied, they are loaded in the order they are specified on the command line.
 

--- a/prapti/tool/__init__.py
+++ b/prapti/tool/__init__.py
@@ -80,10 +80,10 @@ def locate_user_config_file_path(log: DiagnosticsLogger) -> pathlib.Path | None:
             result = pathlib.Path.home() / '.prapti' / 'config.md'
 
     if result.exists() and result.is_file():
-        log.detail(f"using user config file at '{result}'")
+        log.detail(f"using user config file '{result}'")
         return result
     else:
-        log.detail("could not locate a user config file.")
+        log.detail("no user config file found (not a problem unless you thought you'd created one)")
         return None
 
 def load_config_file(config_path: pathlib.Path, state: ExecutionState) -> bool:

--- a/prapti/tool/__init__.py
+++ b/prapti/tool/__init__.py
@@ -2,12 +2,13 @@
     Command line tool for generating markdown chat responses
 """
 import argparse
+import os
 import pathlib
 from typing import Sequence, TextIO
 from dataclasses import dataclass
 
 from ..__init__ import __version__
-from ..core.logger import create_diagnostics_logger
+from ..core.logger import create_diagnostics_logger, DiagnosticsLogger
 from ..core._core_execution_state import CoreExecutionState
 from ..core.execution_state import ExecutionState
 from ..core.chat_markdown_parser import parse_messages
@@ -46,6 +47,45 @@ def parse_messages_and_interpret_commands(lines: list[str], file_path: pathlib.P
     # this step does not modify the message sequence
     state.message_sequence += message_sequence
 
+def locate_user_config_file_path(log: DiagnosticsLogger) -> pathlib.Path | None:
+    """Compute the location of the user's prapti config.md file.
+
+    If the XDG_CONFIG_HOME environment variable is set and not empty,
+    the user config file must be located at:
+        $XDG_CONFIG_HOME/prapti/config.md
+
+    Otherwise, search in the following locations:
+        ~/.config/prapti/config.md (the XDG-compatible default location)
+        ~/.prapti/config.md (the legacy location)
+    """
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME", None)
+    if xdg_config_home: # set, not empty
+        log.detail("checking for user config file at '$XDG_CONFIG_HOME/prapti/config.md' because the XDG_CONFIG_HOME environment variable is set")
+        xdg_config_home_path = pathlib.Path(xdg_config_home)
+        if xdg_config_home_path.exists() and xdg_config_home_path.is_dir():
+            result = xdg_config_home_path / "prapti" / "config.md"
+        else:
+            log.warning("bad-xdg-config-home", f"will not load user config file. XDG_CONFIG_HOME environment variable is set to '{xdg_config_home}' but this is not an existing directory")
+            return None
+    else: # XDG_CONFIG_HOME environment var empty or not set
+        # try the default XDG path
+        log.detail("checking for user config file at '$HOME/.config/prapti/config.md'")
+        default_xdg_config_home = pathlib.Path.home() / ".config"
+        if (default_xdg_config_home / "prapti").exists():
+            # if there is an XDG-compatible prapti directory, always use it, don't check $HOME/.prapti
+            result = default_xdg_config_home / "prapti" / "config.md"
+        else:
+            # fall back to legacy configuration file location
+            log.detail("checking for user config file at '$HOME/.prapti/config.md'")
+            result = pathlib.Path.home() / '.prapti' / 'config.md'
+
+    if result.exists() and result.is_file():
+        log.detail(f"using user config file at '{result}'")
+        return result
+    else:
+        log.detail("could not locate a user config file.")
+        return None
+
 def load_config_file(config_path: pathlib.Path, state: ExecutionState) -> bool:
     """load the config file at `config_path` into `state`, if it exists.
         return `True` if the config file exists as a file, whether or not it
@@ -70,8 +110,8 @@ def default_load_config_files(state: ExecutionState):
     """
     found_config_file = False
 
-    # user config file i.e. ~/.prapti/config.md
-    found_config_file |= load_config_file(pathlib.Path.home() / '.prapti' / 'config.md', state)
+    if user_config_file_path := locate_user_config_file_path(state.log):
+        found_config_file |= load_config_file(user_config_file_path, state)
 
     # in-tree `.prapticonfig.md` files:
     # (.editorconfig algorithm) starting from the directory containing the input markdown file,

--- a/tests/test_config_files.py
+++ b/tests/test_config_files.py
@@ -1,0 +1,296 @@
+import pathlib
+
+from prapti.core.execution_state import ExecutionState
+from prapti.plugins.prapti_test_responder import TestResponderConfiguration
+
+MINIMAL_PROMPT_MD = """\
+### @user:
+Hello
+"""
+
+MOCK_RESPONDER_CONFIG = """\
+Load a responder, but we don't expect this to load
+% plugins.load prapti.test.test_responder
+% responder.new default prapti.test.test_responder
+"""
+def test_no_default_config(tmp_path: pathlib.Path, monkeypatch):
+    """Test that when the --no-default-config flag is specified, no default responder is loaded"""
+
+    # set up mock user config.md and prapticonfig.md in all the places, so we can check that none of them load
+
+    # set up mocked XDG_CONFIG_HOME and write config.md
+    mock_xdg_config_home = tmp_path / "mock_xdg_config_home"
+    mock_xdg_config_home.mkdir()
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(mock_xdg_config_home))
+
+    mock_prapti_config_dir_1 = mock_xdg_config_home / "prapti"
+    mock_prapti_config_dir_1.mkdir()
+
+    mock_user_home = tmp_path / "mock_user_home"
+
+    mock_prapti_config_dir_2 = mock_user_home / ".config" / "prapti"
+    mock_prapti_config_dir_2.mkdir(parents=True)
+
+    mock_prapti_config_dir_3 = mock_user_home / ".prapti"
+    mock_prapti_config_dir_3.mkdir(parents=True)
+
+    for mock_prapti_config_dir in (mock_prapti_config_dir_1, mock_prapti_config_dir_2, mock_prapti_config_dir_3):
+        (mock_prapti_config_dir / "config.md").write_text(MOCK_RESPONDER_CONFIG, encoding="utf-8")
+
+    # minimal md input file
+    temp_md_path = tmp_path / "test_no_default_config.md"
+    temp_md_path.write_text(MINIMAL_PROMPT_MD, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", "--no-default-config", str(temp_md_path)])
+
+    import prapti.tool
+    test_exfil = {}
+    exit_status = prapti.tool.main(test_exfil=test_exfil)
+    assert exit_status != 0 # expect error: no default responder
+
+    state: ExecutionState = test_exfil["state"]
+    assert not hasattr(state.root_config.responders, "default")
+
+def test_fallback_config(tmp_path: pathlib.Path, monkeypatch):
+    """Test that when no .prapticonfig.md nor user config.md is present, a default responder is loaded (via the fallback configuration)"""
+
+    # clear XDG_CONFIG_HOME, set up mocked user home directory
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    mock_user_home = tmp_path / "mock_user_home"
+    mock_user_home.mkdir()
+    monkeypatch.setenv("HOME", str(mock_user_home))
+    def mock_home_func():
+        return mock_user_home
+    monkeypatch.setattr(pathlib.Path, "home", mock_home_func)
+
+    # leave mock user home empty. i.e. no user config
+
+    # minimal md input file
+    temp_md_path = tmp_path / "test_fallback_config.md"
+    temp_md_path.write_text(MINIMAL_PROMPT_MD, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", str(temp_md_path)])
+
+    import prapti.tool
+    test_exfil = {}
+    exit_status = prapti.tool.main(test_exfil=test_exfil)
+    assert exit_status == 0
+
+    state: ExecutionState = test_exfil["state"]
+    assert hasattr(state.root_config.responders, "default")
+
+XDG_CONFIG_HOME_CONFIG = """\
+% plugins.load prapti.test.test_responder
+% responder.new default prapti.test.test_responder
+% responders.default.a_string = "Loaded from $XDG_CONFIG_HOME/prapti/config.md"
+"""
+def test_load_user_config_from_xdg_config_home(tmp_path: pathlib.Path, monkeypatch):
+    """Test loading user config from $XDG_CONFIG_HOME/prapti/config.md when present"""
+
+    # set up mocked XDG_CONFIG_HOME and write config.md
+    mock_xdg_config_home = tmp_path / "mock_xdg_config_home"
+    mock_xdg_config_home.mkdir()
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(mock_xdg_config_home))
+
+    mock_prapti_config_dir = mock_xdg_config_home / "prapti"
+    mock_prapti_config_dir.mkdir()
+
+    (mock_prapti_config_dir / "config.md").write_text(XDG_CONFIG_HOME_CONFIG, encoding="utf-8")
+
+    # minimal md input file
+    temp_md_path = tmp_path / "test_load_user_config_from_xdg_config_home.md"
+    temp_md_path.write_text(MINIMAL_PROMPT_MD, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", str(temp_md_path)])
+
+    import prapti.tool
+    test_exfil = {}
+    exit_status = prapti.tool.main(test_exfil=test_exfil)
+    assert exit_status == 0
+
+    state: ExecutionState = test_exfil["state"]
+    assert state.root_config.responders.default.a_string == "Loaded from $XDG_CONFIG_HOME/prapti/config.md"
+
+DEFAULT_XDG_CONFIG_HOME_CONFIG = """\
+% plugins.load prapti.test.test_responder
+% responder.new default prapti.test.test_responder
+% responders.default.a_string = "Loaded from ~/.config/prapti/config.md"
+"""
+def test_load_user_config_from_default_xdg_config_home(tmp_path: pathlib.Path, monkeypatch):
+    """Test loading user config from ~/.config/prapti/config.md when present"""
+
+    # clear XDG_CONFIG_HOME, set up mocked user home directory, and write config.md
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    mock_user_home = tmp_path / "mock_user_home"
+    mock_user_home.mkdir()
+    monkeypatch.setenv("HOME", str(mock_user_home))
+    def mock_home_func():
+        return mock_user_home
+    monkeypatch.setattr(pathlib.Path, "home", mock_home_func)
+
+    mock_default_xdg_config_home = mock_user_home / ".config"
+    mock_default_xdg_config_home.mkdir()
+
+    mock_prapti_config_dir = mock_default_xdg_config_home / "prapti"
+    mock_prapti_config_dir.mkdir()
+
+    (mock_prapti_config_dir / "config.md").write_text(DEFAULT_XDG_CONFIG_HOME_CONFIG, encoding="utf-8")
+
+    # minimal md input file
+    temp_md_path = tmp_path / "test_load_user_config_from_default_xdg_config_home.md"
+    temp_md_path.write_text(MINIMAL_PROMPT_MD, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", str(temp_md_path)])
+
+    import prapti.tool
+    test_exfil = {}
+    exit_status = prapti.tool.main(test_exfil=test_exfil)
+    assert exit_status == 0
+
+    state: ExecutionState = test_exfil["state"]
+    assert state.root_config.responders.default.a_string == "Loaded from ~/.config/prapti/config.md"
+
+LEGACY_CONFIG_HOME_CONFIG = """\
+% plugins.load prapti.test.test_responder
+% responder.new default prapti.test.test_responder
+% responders.default.a_string = "Loaded from ~/.prapti/config.md"
+"""
+def test_load_user_config_from_legacy_config_home(tmp_path: pathlib.Path, monkeypatch):
+    """Test loading user config from ~/.prapti/config.md when present"""
+
+    # clear XDG_CONFIG_HOME, set up mocked user home directory, and write config.md
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    mock_user_home = tmp_path / "mock_user_home"
+    mock_user_home.mkdir()
+    monkeypatch.setenv("HOME", str(mock_user_home))
+    def mock_home_func():
+        return mock_user_home
+    monkeypatch.setattr(pathlib.Path, "home", mock_home_func)
+
+    mock_prapti_config_dir = mock_user_home / ".prapti"
+    mock_prapti_config_dir.mkdir()
+
+    (mock_prapti_config_dir / "config.md").write_text(LEGACY_CONFIG_HOME_CONFIG, encoding="utf-8")
+
+    # minimal md input file
+    temp_md_path = tmp_path / "test_load_user_config_from_legacy_config_home.md"
+    temp_md_path.write_text(MINIMAL_PROMPT_MD, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", str(temp_md_path)])
+
+    import prapti.tool
+    test_exfil = {}
+    exit_status = prapti.tool.main(test_exfil=test_exfil)
+    assert exit_status == 0
+
+    state: ExecutionState = test_exfil["state"]
+    assert state.root_config.responders.default.a_string == "Loaded from ~/.prapti/config.md"
+
+XDG_CONFIG_HOME_CONFIG_NO_RESPONDER = """\
+% plugins.load prapti.test.test_config
+% plugins.prapti.test.test_config.a_string = "Loaded from $XDG_CONFIG_HOME/prapti/config.md"
+"""
+def test_load_user_config_inhibits_fallback_config(tmp_path: pathlib.Path, monkeypatch):
+    """Test that when a user config.md is provided, no fallback default responder is loaded"""
+
+    # set up mocked XDG_CONFIG_HOME and write config.md
+    mock_xdg_config_home = tmp_path / "mock_xdg_config_home"
+    mock_xdg_config_home.mkdir()
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(mock_xdg_config_home))
+
+    mock_prapti_config_dir = mock_xdg_config_home / "prapti"
+    mock_prapti_config_dir.mkdir()
+
+    (mock_prapti_config_dir / "config.md").write_text(XDG_CONFIG_HOME_CONFIG_NO_RESPONDER, encoding="utf-8")
+
+    # minimal md input file
+    temp_md_path = tmp_path / "test_load_user_config_inhibits_fallback_config.md"
+    temp_md_path.write_text(MINIMAL_PROMPT_MD, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", str(temp_md_path)])
+
+    import prapti.tool
+    test_exfil = {}
+    exit_status = prapti.tool.main(test_exfil=test_exfil)
+    assert exit_status == 1 # expect error: no default responder
+
+    state: ExecutionState = test_exfil["state"]
+    assert state.root_config.plugins.prapti.test.test_config.a_string == "Loaded from $XDG_CONFIG_HOME/prapti/config.md"
+
+PRAPTI_CONFIG_MD = """\
+% plugins.load prapti.test.test_responder
+% responder.new default prapti.test.test_responder
+% responders.default.a_string = "Loaded from .prapticonfig.md"
+"""
+def test_prapticonfig_md(tmp_path: pathlib.Path, monkeypatch):
+    """Test loading configuration from prapticonfig.md"""
+
+    # clear XDG_CONFIG_HOME, set up empty mocked user home directory
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    mock_user_home = tmp_path / "mock_user_home"
+    mock_user_home.mkdir()
+    monkeypatch.setenv("HOME", str(mock_user_home))
+    def mock_home_func():
+        return mock_user_home
+    monkeypatch.setattr(pathlib.Path, "home", mock_home_func)
+
+    # leave mock user home empty. i.e. no user config
+
+    # .prapticonfig.md
+    temp_prapticonfig_md_path = tmp_path / ".prapticonfig.md"
+    temp_prapticonfig_md_path.write_text(PRAPTI_CONFIG_MD, encoding="utf-8")
+
+    # minimal md input file
+    temp_md_path = tmp_path / "test_prapticonfig_md.md"
+    temp_md_path.write_text(MINIMAL_PROMPT_MD, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", str(temp_md_path)])
+
+    import prapti.tool
+    test_exfil = {}
+    exit_status = prapti.tool.main(test_exfil=test_exfil)
+    assert exit_status == 0
+
+    state: ExecutionState = test_exfil["state"]
+    assert state.root_config.responders.default.a_string == "Loaded from .prapticonfig.md"
+
+PRAPTI_CONFIG_MD_NO_RESPONDER = """\
+% plugins.load prapti.test.test_config
+% plugins.prapti.test.test_config.a_string = "Loaded from .prapticonfig.md"
+"""
+def test_load_prapticonfig_md_inhibits_fallback_config(tmp_path: pathlib.Path, monkeypatch):
+    """Test that when a prapticonfig.md is provided, no fallback default responder is loaded"""
+
+    # clear XDG_CONFIG_HOME, set up empty mocked user home directory
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    mock_user_home = tmp_path / "mock_user_home"
+    mock_user_home.mkdir()
+    monkeypatch.setenv("HOME", str(mock_user_home))
+    def mock_home_func():
+        return mock_user_home
+    monkeypatch.setattr(pathlib.Path, "home", mock_home_func)
+
+    # leave mock user home empty. i.e. no user config
+
+    # .prapticonfig.md
+    temp_prapticonfig_md_path = tmp_path / ".prapticonfig.md"
+    temp_prapticonfig_md_path.write_text(PRAPTI_CONFIG_MD_NO_RESPONDER, encoding="utf-8")
+
+    # minimal md input file
+    temp_md_path = tmp_path / "test_load_prapticonfig_md_inhibits_fallback_config.md"
+    temp_md_path.write_text(MINIMAL_PROMPT_MD, encoding="utf-8")
+
+    monkeypatch.setattr("sys.argv", ["prapti", "--strict", "--dry-run", str(temp_md_path)])
+
+    import prapti.tool
+    test_exfil = {}
+    exit_status = prapti.tool.main(test_exfil=test_exfil)
+    assert exit_status == 1 # expect error: no default responder
+
+    state: ExecutionState = test_exfil["state"]
+    assert state.root_config.plugins.prapti.test.test_config.a_string == "Loaded from .prapticonfig.md"


### PR DESCRIPTION
support loading user config from $XDG_CONFIG_HOME/prapti/config.md add ~/.config/prapti/config.md in addition to ~/.prapti/config.md + associated tests. resolves #10