### PR TITLE
Big refactor that changes Responder interface to return async streaming responses.

### DIFF
--- a/prapti/core/command_message.py
+++ b/prapti/core/command_message.py
@@ -5,7 +5,7 @@
     chat Messages, each of which may contain interjecting Commands.
 """
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, AsyncGenerator
 from .source_location import SourceLocation
 
 @dataclass
@@ -26,11 +26,12 @@ class Message:
     content: list[str|Command|None]
         # ^^^ allow embedded inline commands e.g. for file inclusion
         # also allow "None" items so that command outputs can be re-written to None without otherwise modifying the list
+    async_content: AsyncGenerator[str, None]|None = None
     is_enabled: bool = True
     source_loc: SourceLocation = field(default_factory=SourceLocation)
 
     @property
-    def is_private(self) -> bool:
+    def is_hidden(self) -> bool:
         return self.role.startswith("_")
 
     def content_is_empty(self) -> bool:

--- a/prapti/core/configuration.py
+++ b/prapti/core/configuration.py
@@ -61,7 +61,8 @@ class Vars(SimpleNamespace):
     def __init__(self):
         self.model = VarEntry() # str
         self.temperature = VarEntry() # float
-        self.n = VarEntry() # int, number of responses to generate
+        self.n = VarEntry(value=1) # int, number of responses to generate
+        self.stream = VarEntry(value=True)
 
 class RootConfiguration(BaseModel):
     """The root of the configuration tree"""

--- a/prapti/core/load_configuration.py
+++ b/prapti/core/load_configuration.py
@@ -29,7 +29,7 @@ def load_config_file(config_path: pathlib.Path, state: ExecutionState) -> bool:
     loads without error.
     """
     if config_path.is_file():
-        state.log.info("loading-config", "loading configuration file", config_path)
+        state.log.info("loading-config-file", "loading configuration file", config_path)
         state.config_file_paths.append(config_path)
         try:
             config_file_lines = config_path.read_text(encoding="utf-8").splitlines(keepends=True)

--- a/prapti/core/responder.py
+++ b/prapti/core/responder.py
@@ -7,8 +7,10 @@
 import abc
 from typing import Any
 from dataclasses import dataclass
+from typing import AsyncGenerator
 
 from pydantic import BaseModel
+from cancel_token import CancellationToken
 
 from .command_message import Message
 from .configuration import RootConfiguration, VarRef
@@ -33,5 +35,5 @@ class Responder(metaclass=abc.ABCMeta):
         return None
 
     @abc.abstractmethod
-    def generate_responses(self, input_: list[Message], context: ResponderContext) -> list[Message]:
+    def generate_responses(self, input_: list[Message], cancellation_token: CancellationToken, context: ResponderContext) -> AsyncGenerator[Message, None]:
         pass

--- a/prapti/plugins/endpoints/koboldcpp_text_responder.py
+++ b/prapti/plugins/endpoints/koboldcpp_text_responder.py
@@ -9,11 +9,14 @@
                 https://github.com/LostRuins/koboldcpp/blob/concedo/koboldcpp.py
 """
 import datetime
-from typing import Literal
+from typing import Literal, AsyncGenerator, Any
 import json
+import asyncio
+from contextlib import suppress
 
-import requests
+import aiohttp
 from pydantic import BaseModel, ConfigDict, Field
+from cancel_token import CancellationToken
 
 from ...core.plugin import Plugin, PluginCapabilities, PluginContext
 from ...core.command_message import Message
@@ -26,7 +29,7 @@ class KoboldcppResponderConfiguration(BaseModel):
     model_config = ConfigDict(
         validate_assignment=True)
 
-    api_base: str = "http://localhost:5001/api/v1"
+    api_base: str = "http://localhost:5001/api/v1"  # "api_format 2" in koboldcpp
 
     max_context_length: int|None = None
     max_length: int = 50
@@ -44,19 +47,19 @@ class KoboldcppResponderConfiguration(BaseModel):
     sampler_order: list[int] = Field(default_factory=lambda: list([6,0,1,3,4,2,5])) # max len sampler_order_max
     seed: int = -1
     stop_sequence: list[str] = Field(default_factory=list) # max len stop_token_max
+    stream: bool = True
 
     # TODO:
-    # n number of generations
-    # stream via generate/stream route
+    # n -- number of generated responses
 
 def convert_message_sequence_to_text_prompt(message_sequence: list[Message], log: DiagnosticsLogger) -> str:
     result = ""
     for message in message_sequence:
-        if not message.is_enabled or message.is_private:
-            continue # skip disabled and private messages
+        if not message.is_enabled or message.is_hidden:
+            continue # skip disabled and hidden messages
 
         if message.role == "prompt":
-            assert len(message.content) == 1 and isinstance(message.content[0], str), "koboldcpp.text: expected flattened message content"
+            assert len(message.content) == 1 and isinstance(message.content[0], str), "koboldcpp.text: internal error. expected flattened message content"
             result += message.content[0]
         elif message.role in ("user", "assistant"):
             log.warning("unsupported-chat-role", f"message will not be included in LLM prompt. role '{message.role}' is not supported. use '### @prompt:'.", message.source_loc)
@@ -66,11 +69,114 @@ def convert_message_sequence_to_text_prompt(message_sequence: list[Message], log
 
     return result
 
+
+def _rstrip_eol(line: str) -> str:
+    # as per the server-sent-events spec: "Lines must be separated by either a U+000D CARRIAGE RETURN U+000A LINE FEED (CRLF)
+    # character pair, a single U+000A LINE FEED (LF) character, or a single U+000D CARRIAGE RETURN (CR) character."
+    # we strip any valid line ending from the end of /line/
+    if line.endswith("\r\n"):
+        return line[:-2]
+    elif line.endswith("\n") or line.endswith("\r"):
+        return line[:-1]
+    return line
+
+async def _generate_async_content(session: aiohttp.ClientSession, response: aiohttp.ClientResponse, cancellation_token: CancellationToken) -> AsyncGenerator[str, None]:
+    """process server sent events as they are received, yielding the string data contained in the json payloads, e.g.:
+
+        b'event: message\n'
+        b'data: {"token": " last"}\n'
+        b'\n'
+        b'event: message\n'
+        b'data: {"token": " few"}\n'
+        b'\n'
+        b'event: message\n'
+        b'data: {"token": " months"}\n'
+        b'\n'
+    """
+    # https://blog.axway.com/learning-center/apis/api-streaming/server-sent-events
+    # https://www.w3.org/TR/2012/WD-eventsource-20120426/
+    # REVIEW: consider using https://pypi.org/project/aiohttp-sse-client2/ instead of rolling our own
+    # note that koboldcpp returns the full json completion response after the server sent events,
+    # not sure that is conformant, not sure whether that will play nice with aiohttp-sse-client2
+
+    try:
+        event_name, data = "message", "" # default init/reset
+
+        async for bline in response.content:
+            line = _rstrip_eol(bline.decode(encoding="utf-8"))
+            if not line:
+                # dispatch the message
+                if event_name == "message" and data:
+                    try:
+                        json_data = json.loads(data)
+                        if "token" in json_data:
+                            yield json_data["token"]
+                    except ValueError:
+                        pass
+                event_name, data = "message", "" # default init/reset
+                continue
+            elif line.startswith(":"):
+                continue # ignore comment lines
+            elif ":" in line:
+                field,value = line.split(":", maxsplit=1)
+                if value.startswith(" "):
+                    value = value[1:]
+            else:
+                field = line
+                value = ""
+
+            match field:
+                case "event":
+                    event_name = value
+                case "data":
+                    data += value
+                    data += "\n"
+                case "id":
+                    pass # not needed, not implemented
+                case "retry":
+                    pass # not needed, not implemented
+                case _:
+                    pass # ignore unknown fields as specified
+    except aiohttp.ClientConnectionError:
+        # eat connection error if the stream has been cancelled, it's probably a result of our
+        # closing the connection and even if it isn't we can reasonably treat the error as-if cancelled.
+        if not cancellation_token.cancelled:
+            raise
+    finally:
+        await session.close()
+
+async def _get_streaming_response(api_base: str, prompt: str, generate_args: dict[str, Any], timeout: float, cancellation_token: CancellationToken) -> Message:
+    route = api_base.replace("/api/v1", "/api/extra") + "/generate/stream"
+    # NOTE: we can not use context managers (`async with`) here, because we need the session to
+    # remain active until async content streaming completes in _generate_async_content() completes
+    session = aiohttp.ClientSession()
+    try:
+        cancellation_token.on_cancel(lambda: _discard_arg(asyncio.create_task(session.close())))
+        response = await session.post(route, json={"prompt": prompt, **generate_args}, timeout=timeout)
+        return Message(role="completion", name=None, content=[], async_content=_generate_async_content(session, response, cancellation_token))
+        # ^^^ NOTE: _generate_async_content consumes `session` and is responsible for closing `session`.
+    except (Exception, asyncio.CancelledError):
+        await session.close()
+        raise
+
+async def _get_non_streaming_response(api_base: str, prompt: str, generate_args: dict[str, Any], timeout: float) -> Message:
+    route = f"{api_base}/generate"
+    async with aiohttp.ClientSession() as session:
+        async with session.post(route, json={"prompt": prompt, **generate_args}, timeout=timeout) as response:
+            response_json = await response.json()
+            response_text = response_json["results"][0]["text"]
+            return Message(role="completion", name=None, content=[response_text], async_content=None)
+
+def _discard_arg(arg: Any) -> None:
+    return None
+
 class KoboldcppResponder(Responder):
     def construct_configuration(self, context: ResponderContext) -> BaseModel|tuple[BaseModel, list[tuple[str,VarRef]]]|None:
-        return KoboldcppResponderConfiguration(), [("temperature", VarRef("temperature"))]
+        return KoboldcppResponderConfiguration(), [
+            ("temperature", VarRef("temperature")),
+            ("stream", VarRef("stream"))]
 
-    def generate_responses(self, input_: list[Message], context: ResponderContext) -> list[Message]:
+    async def _async_response_generator(self, input_: list[Message], cancellation_token: CancellationToken, context: ResponderContext) -> AsyncGenerator[Message, None]:
         config: KoboldcppResponderConfiguration = context.responder_config
         context.log.debug(f"koboldcpp.text: input: {config = }", context.state.input_file_path)
         config = resolve_var_refs(config, context.root_config, context.log)
@@ -79,21 +185,41 @@ class KoboldcppResponder(Responder):
         prompt = convert_message_sequence_to_text_prompt(input_, context.log)
         if not prompt:
             context.log.error("koboldcpp.text: can't generate completion. prompt is empty.")
-            return []
+            return
 
         if context.root_config.prapti.dry_run:
             context.log.info("koboldcpp-text-dry-run", "koboldcpp.text: dry run: bailing before hitting the Kobold API", context.state.input_file_path)
             current_time = str(datetime.datetime.now())
-            return [Message(role="assistant", name=None, content=[f"dry run mode. {current_time}\nconfig = {json.dumps(config.model_dump())}"])]
+            yield Message(role="assistant", name=None, content=[f"dry run mode. {current_time}\nconfig = {json.dumps(config.model_dump())}"])
+            return
 
         generate_args = config.model_dump(exclude_none=True, exclude_defaults=True)
         context.log.debug(f"koboldcpp.text: {generate_args = }")
 
-        response = requests.post(f"{config.api_base}/generate", json={"prompt": prompt, **generate_args}, timeout=1000)
-        response_json = response.json()
-        response_text = response_json["results"][0]["text"]
+        if cancellation_token.cancelled:
+            return
+        try:
+            timeout = 1000 # TODO: expose timeout in config
 
-        return [Message(role="completion", name=None, content=[response_text])]
+            if config.stream:
+                task = asyncio.create_task(_get_streaming_response(config.api_base, prompt, generate_args, timeout, cancellation_token))
+                cancellation_token.on_cancel(lambda: _discard_arg(task.cancel()))
+                with suppress(asyncio.CancelledError):
+                    yield await task
+                    # NOTE: fall through and return here even though the async content may still be streaming
+                    # this is not required behavior, it is one allowed behavior
+            else:
+                task = asyncio.create_task(_get_non_streaming_response(config.api_base, prompt, generate_args, timeout))
+                cancellation_token.on_cancel(lambda: _discard_arg(task.cancel()))
+                with suppress(asyncio.CancelledError):
+                    yield await task
+
+        except Exception as ex:
+            context.state.log.error("koboldcpp-text-api-exception", f"exception while requesting a response from koboldcpp: {repr(ex)}", context.state.input_file_path)
+            context.state.log.logger.debug(ex, exc_info=True)
+
+    def generate_responses(self, input_: list[Message], cancellation_token: CancellationToken, context: ResponderContext) -> AsyncGenerator[Message, None]:
+        return self._async_response_generator(input_, cancellation_token, context)
 
 class KoboldcppResponderPlugin(Plugin):
     def __init__(self):

--- a/prapti/plugins/endpoints/local_openai_chat_responder.md
+++ b/prapti/plugins/endpoints/local_openai_chat_responder.md
@@ -13,7 +13,7 @@ Here we'll use GPT4ALL:
 
 Depending on the server, you will need to specify the model file either here, or in the server settings:
 
-%model = "ggml-mpt-7b-chat.bin"
+%model = "nous-hermes-13b.ggmlv3.q4_0.bin"
 
 %responders.default.max_tokens = 500
 

--- a/prapti/plugins/endpoints/local_openai_chat_responder.py
+++ b/prapti/plugins/endpoints/local_openai_chat_responder.py
@@ -8,8 +8,13 @@
 import datetime
 import inspect
 import json
+from enum import Enum
+from typing import AsyncGenerator, Any
+import asyncio
+from contextlib import suppress
 
 from pydantic import BaseModel, Field, ConfigDict
+from cancel_token import CancellationToken
 import openai
 
 from . import openai_globals # ensure openai globals are saved, no matter which module is loaded first
@@ -59,12 +64,13 @@ class LocalOpenAIChatResponderConfiguration(BaseModel):
     n: int = Field(default=1, description=inspect.cleandoc("""\
         How many chat completion choices to generate for each input message."""))
 
-    # stream: bool (not supported, yet)
+    stream: bool = Field(default=False, description=inspect.cleandoc("""\
+        If set, partial message fragments will be returned progressively as they are generated."""))
 
     stop: str|list[str]|None = Field(default=None, description=inspect.cleandoc("""\
         Up to 4 sequences where the API will stop generating further tokens."""))
 
-    max_tokens: int|None = Field(default=250, description=inspect.cleandoc("""\
+    max_tokens: int|None = Field(default=None, description=inspect.cleandoc("""\
         The maximum number of tokens to generate in the chat completion.
 
         The total length of input tokens and generated tokens is limited by the model's context length.
@@ -94,8 +100,8 @@ class LocalOpenAIChatResponderConfiguration(BaseModel):
 def convert_message_sequence_to_openai_messages(message_sequence: list[Message], log: DiagnosticsLogger) -> list[dict]:
     result = []
     for message in message_sequence:
-        if not message.is_enabled or message.is_private:
-            continue # skip disabled and private messages
+        if not message.is_enabled or message.is_hidden:
+            continue # skip disabled and hidden messages
 
         if message.role not in ["system", "user", "assistant"]:
             log.warning("unrecognised-public-role", f"message will not be included in LLM prompt. public role '{message.role}' is not recognised.", message.source_loc)
@@ -114,18 +120,78 @@ def convert_message_sequence_to_openai_messages(message_sequence: list[Message],
         result.append(m)
     return result
 
+class QueueSentinel(Enum):
+    END_OF_RESPONSE = 0
+
+async def _cancel_async_generator(agen: AsyncGenerator) -> None:
+    # https://stackoverflow.com/questions/60226557/how-to-forcefully-close-an-async-generator
+    task = asyncio.create_task(agen.__anext__())
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
+
+async def _stream_chunks_task(chunks: AsyncGenerator[dict, None], queues: list[asyncio.Queue[str|QueueSentinel]]) -> None:
+    """receive chunks from the async generator returned by openai.ChatCompletion.acreate
+    and route each chunk into the appropriate queue. this part of the receive process is cancelable.
+    """
+    async for chunk in chunks:
+        if chunk["choices"]:
+            choices = chunk["choices"]
+            for choice in choices:
+                index = choice["index"]
+                delta = choice["delta"]
+                if "content" in delta:
+                    if bool(delta_content := delta["content"]):
+                        queues[index].put_nowait(delta_content)
+
+async def _streaming_receive_task(chunks: AsyncGenerator[dict, None], queues: list[asyncio.Queue[str|QueueSentinel]], cancellation_token: CancellationToken) -> None:
+    """stream chunks from the async generator returned by openai.ChatCompletion.acreate
+    and route to queues using _stream_chunks_task.
+    handle cancellation and ensure that all queues are terminated with a END_OF_RESPONSE item
+    both at the end of processing and if cancelled."""
+    try:
+        receive_chunks_task = asyncio.create_task(_stream_chunks_task(chunks, queues))
+        cancellation_token.on_cancel(lambda: _discard_arg(receive_chunks_task.cancel()))
+
+        with suppress(asyncio.CancelledError):
+            await receive_chunks_task
+
+        if cancellation_token.cancelled:
+            # cancel the source, i.e. the AsyncGenerator that openai.ChatCompletion.acreate gave us
+            with suppress(asyncio.CancelledError):
+                await _cancel_async_generator(chunks)
+    finally:
+        # terminate the queues. note that this needs to happen under all cancellation and error scenarios
+        for queue in queues:
+            queue.put_nowait(QueueSentinel.END_OF_RESPONSE)
+
+async def _dequeue_async_content(queue) -> AsyncGenerator[str, None]:
+    while True:
+        s = await queue.get()
+        if s == QueueSentinel.END_OF_RESPONSE:
+            return
+        yield s
+
+def _discard_arg(arg: Any) -> None:
+    return None
+
 class LocalOpenAIChatResponder(Responder):
     def construct_configuration(self, context: ResponderContext) -> BaseModel|tuple[BaseModel, list[tuple[str,VarRef]]]|None:
-        return LocalOpenAIChatResponderConfiguration(), [("api_base", VarRef("local_openai_api_base")), ("model", VarRef("model")), ("temperature", VarRef("temperature")), ("n", VarRef("n"))]
+        return LocalOpenAIChatResponderConfiguration(), [
+            ("api_base", VarRef("local_openai_api_base")),
+            ("model", VarRef("model")),
+            ("temperature", VarRef("temperature")),
+            ("n", VarRef("n")),
+            ("stream", VarRef("stream"))]
 
-    def generate_responses(self, input_: list[Message], context: ResponderContext) -> list[Message]:
+    async def _async_response_generator(self, input_: list[Message], cancellation_token: CancellationToken, context: ResponderContext) -> AsyncGenerator[Message, None]:
         config: LocalOpenAIChatResponderConfiguration = context.responder_config
         context.log.debug(f"local.openai.chat: input: {config = }", context.state.input_file_path)
         config = resolve_var_refs(config, context.root_config, context.log)
         context.log.debug(f"local.openai.chat: resolved: {config = }", context.state.input_file_path)
 
-        openai.api_key = "EMPTY"
-        openai.organization = "EMPTY"
+        openai.api_key = "NONE"
+        openai.organization = "NONE"
         openai.api_base = config.api_base
         openai.api_type = "open_ai"
         openai.api_version = None
@@ -142,20 +208,58 @@ class LocalOpenAIChatResponder(Responder):
             context.log.info("openai.chat-dry-run", "local.openai.chat: dry run: bailing before hitting the OpenAI API", context.state.input_file_path)
             current_time = str(datetime.datetime.now())
             chat_args["messages"] = ["..."] # avoid overly long output
-            return [Message(role="assistant", name=None, content=[f"dry run mode. {current_time}\nchat_args = {json.dumps(chat_args)}"])]
+            yield Message(role="assistant", name=None, content=[f"dry run mode. {current_time}\nchat_args = {json.dumps(chat_args)}"])
+            return
 
-        # docs: https://platform.openai.com/docs/api-reference/chat/create
-        response = openai.ChatCompletion.create(**chat_args)
-        context.log.debug(f"local.openai.chat: {response = }", context.state.input_file_path)
+        if cancellation_token.cancelled:
+            return
+        try:
+            # docs: https://platform.openai.com/docs/api-reference/chat/create
+            if config.stream:
+                # https://github.com/openai/openai-cookbook/blob/main/examples/How_to_stream_completions.ipynb
+                task = asyncio.create_task(openai.ChatCompletion.acreate(**chat_args))
+                cancellation_token.on_cancel(lambda: _discard_arg(task.cancel()))
+                chunks = None
+                with suppress(asyncio.CancelledError):
+                    chunks = await task
+                if cancellation_token.cancelled or chunks is None:
+                    return
 
-        if len(response["choices"]) == 1:
-            choice = response["choices"][0]
-            result = [Message(role="assistant", name=None, content=[choice.message["content"].strip()])]
-        else:
-            result = []
-            for i, choice in enumerate(response["choices"], start=1):
-                result.append(Message(role="assistant", name=str(i), content=[choice.message["content"].strip()]))
-        return result
+                queues: list[asyncio.Queue[str|QueueSentinel]] = [asyncio.Queue(maxsize=0) for _ in range(config.n)]
+                # ^^^ unbounded queues -- to avoid constraining caller's response iteration strategy
+                receive_task = asyncio.create_task(_streaming_receive_task(chunks, queues, cancellation_token))
+
+                if config.n == 1:
+                    yield Message(role="assistant", name=None, content=[], async_content=_dequeue_async_content(queues[0]))
+                else:
+                    for i, queue in enumerate(queues, start=1):
+                        yield Message(role="assistant", name=str(i), content=[], async_content=_dequeue_async_content(queue))
+
+                await receive_task
+            else:
+                task = asyncio.create_task(openai.ChatCompletion.acreate(**chat_args))
+                cancellation_token.on_cancel(lambda: _discard_arg(task.cancel()))
+                response = None
+                with suppress(asyncio.CancelledError):
+                    response = await task
+                if cancellation_token.cancelled or response is None:
+                    return
+                assert isinstance(response, dict)
+
+                context.log.debug(f"local.openai.chat: {response = }", context.state.input_file_path)
+
+                if len(response["choices"]) == 1:
+                    choice = response["choices"][0]
+                    yield Message(role="assistant", name=None, content=[choice.message["content"]], async_content=None)
+                else:
+                    for i, choice in enumerate(response["choices"], start=1):
+                        yield Message(role="assistant", name=str(i), content=[choice.message["content"]], async_content=None)
+        except Exception as ex:
+            context.state.log.error("local-openai-chat-api-exception", f"exception while requesting a response from the API server: {repr(ex)}", context.state.input_file_path)
+            context.state.log.logger.debug(ex, exc_info=True)
+
+    def generate_responses(self, input_: list[Message], cancellation_token: CancellationToken, context: ResponderContext) -> AsyncGenerator[Message, None]:
+        return self._async_response_generator(input_, cancellation_token, context)
 
 class LocalOpenAIChatResponderPlugin(Plugin):
     def __init__(self):

--- a/prapti/plugins/experimental_agents.py
+++ b/prapti/plugins/experimental_agents.py
@@ -1,4 +1,4 @@
-""""
+"""
     Proof-of-concept for multiple agents
 
     - treat responder instances as agents
@@ -23,8 +23,11 @@
 import copy
 import random
 import re
+from typing import AsyncGenerator
+from asyncio import Semaphore
 
 from pydantic import BaseModel, Field, ConfigDict
+from cancel_token import CancellationToken
 
 from ..core.plugin import Plugin, PluginCapabilities, PluginContext
 from ..core.action import ActionNamespace, ActionContext
@@ -68,13 +71,13 @@ def discuss(name: str, raw_args: str, context: ActionContext) -> None|str|Messag
         context.plugin_config.discussion_group = args[1:]
 
     # TODO: when we add the ability for actions to insert messages before/after the current message
-    # we can kick-off the discussion by @-mentioning the first participant in a private message
+    # we can kick-off the discussion by @-mentioning the first participant in a hidden message
     # right now the user has to @-mention the first user manually to get a specific user to start.
     #return [Message(role="_prapti.experimental.agents", name=None, content=[f"@{agent_name}"])]
     return None
 
 @_actions.add_action("!agents.ask")
-def discuss(name: str, raw_args: str, context: ActionContext) -> None|str|Message:
+def ask(name: str, raw_args: str, context: ActionContext) -> None|str|Message:
     """prompt a single agent.
     usage:
         !agents.ask agent_name
@@ -91,6 +94,14 @@ class AgentsResponderConfiguration(BaseModel):
     """Configuration parameters for agents responder."""
     model_config = ConfigDict(
         validate_assignment=True)
+
+async def _async_message_content_processor(message: Message, async_content: AsyncGenerator[str, None], sem: Semaphore) -> AsyncGenerator[str, None]:
+    try:
+        async for s in async_content:
+            message.content.append(s)
+            yield s
+    finally:
+        sem.release()
 
 class AgentsResponder(Responder):
     """Responder that controls discussion between agents."""
@@ -136,7 +147,7 @@ class AgentsResponder(Responder):
                 break
         return list(participants - set(MRU)) + list(reversed(MRU)) # least recently (or never) mentioned at front
 
-    def _switch_roles_for_selected_agent(self, message_sequence: list[Message], selected_agent_name: str, context: ResponderContext):
+    def _switch_roles_for_selected_agent(self, message_sequence: list[Message], selected_agent_name: str):
         """switch roles in the input message sequence so that names and roles
           appear as if viewed from the selected agent's perspective. i.e. other agents
           appear as users, and only global and the selected agent's system prompts are active."""
@@ -158,7 +169,7 @@ class AgentsResponder(Responder):
                 case _:
                     pass
 
-    def _restore_roles(self, context: ResponderContext):
+    def _restore_switched_roles(self):
         """set name associated with response messages to agent's name"""
 
         # restore message enable and role for next round (in case there is a followup)
@@ -179,21 +190,20 @@ class AgentsResponder(Responder):
                 context.log.error("no-rexponder-for-agent", f"prapti.experimental.agents: discussion_group specifies agent '{agent_name}' but no responder exists with that name.")
         return result
 
-    def generate_responses(self, input_: list[Message], context: ResponderContext) -> list[Message]:
+    async def _async_response_generator(self, input_: list[Message], cancellation_token: CancellationToken, context: ResponderContext) -> AsyncGenerator[Message, None]:
         config: AgentsResponderConfiguration = context.responder_config
         context.log.debug(f"prapti.experimental.agents: input: {config = }", context.state.input_file_path)
         config = resolve_var_refs(config, context.root_config, context.log)
         context.log.debug(f"prapti.experimental.agents: resolved: {config = }", context.state.input_file_path)
 
         message_sequence = copy.deepcopy(input_)
-        responses = []
 
         plugin_config = resolve_var_refs(context.plugin_config, context.root_config, context.log)
         participants: set[str] = self._valid_discussion_group_participants(plugin_config, context)
 
         if not participants:
             context.log.warning("agents-no-participants", "prapti.experimental.agents: could not continue discussion. no valid participants specified in discussion_group.")
-            return []
+            return
 
         all_pending_at_mentions: set[str] = self._compute_pending_at_mentions(message_sequence, context) # all @-mentions, not limited to participants or even agents/responders
         participants_LRU: list[str] = self._compute_participants_LRU(message_sequence, participants, context) # front is least recent
@@ -211,14 +221,47 @@ class AgentsResponder(Responder):
             else:
                 selected_agent_name = participants_LRU[0] # participants_LRU is non-empty here
 
-            self._switch_roles_for_selected_agent(message_sequence, selected_agent_name, context)
-            agent_responses = delegate_generate_responses(context.state, selected_agent_name, message_sequence)
-            self._restore_roles(context)
+            self._switch_roles_for_selected_agent(message_sequence, selected_agent_name)
 
-            for message in agent_responses:
+            async_agent_responses = delegate_generate_responses(context.state, selected_agent_name, message_sequence, cancellation_token)
+            if cancellation_token.cancelled:
+                return
+
+            copied_agent_responses = [] # collect a local copy of the messages
+            async_content_completion_sem = Semaphore(value=0)
+            async_content_count = 0
+            async for message in async_agent_responses:
                 # name assistant responses according to the name of the agent that generated them
                 if message.role == "assistant" and not message.name:
                     message.name = selected_agent_name
+
+                async_content = message.async_content
+                message.async_content = None # avoid deep copying the async content
+
+                # collect a copy of generated messages for synchronous processing within the agent loop
+                message_copy = copy.deepcopy(message)
+                if async_content:
+                    # _async_content_processor passes through the asynchronous stream of message content
+                    # and simultaneously accumulates it into our local copy: message_copy.content
+                    message.async_content = _async_message_content_processor(message_copy, async_content, async_content_completion_sem)
+                    async_content_count += 1
+                copied_agent_responses.append(message_copy)
+
+                # yield the original generated messages to the client for output and streaming
+                yield message
+
+            # wait for all _async_message_content_processor processing to complete
+            # i.e. for all async content to arrive
+            for _ in range(0, async_content_count):
+                await async_content_completion_sem.acquire()
+
+            if cancellation_token.cancelled:
+                return
+
+            self._restore_switched_roles()
+
+            for message in copied_agent_responses:
+                message.content = ["".join(message.content).strip()] # flatten the message content to a single string
 
                 # decrement discussion counter for any messages in discussion, whether @-mentions or other
                 if message.name in context.plugin_config.discussion_group:
@@ -230,15 +273,15 @@ class AgentsResponder(Responder):
                 participants_LRU.remove(selected_agent_name)
                 participants_LRU.append(selected_agent_name)
 
-            message_sequence += agent_responses
-            responses += agent_responses
+            message_sequence += copied_agent_responses
 
             if participant_at_mentions:
                 participant_at_mentions.add(participants_LRU[0])
                 # ^^^ fake @-mention of least-recent participant
                 # this hopefully ensures that all participants get a turn even if they are also @-mentioning each other
 
-        return responses
+    def generate_responses(self, input_: list[Message], cancellation_token: CancellationToken, context: ResponderContext) -> AsyncGenerator[Message, None]:
+        return self._async_response_generator(input_, cancellation_token, context)
 
 # ^^^ END UNDER CONSTRUCTION /////////////////////////////////////////////////
 # ----------------------------------------------------------------------------

--- a/prapti/tool/__init__.py
+++ b/prapti/tool/__init__.py
@@ -4,12 +4,16 @@
 import argparse
 import pathlib
 import sys
-from typing import Sequence, TextIO
-from dataclasses import dataclass
+from typing import Sequence, TextIO, AsyncGenerator
+from dataclasses import dataclass, field
+import asyncio
+from enum import Enum
+
+from cancel_token import CancellationToken
 
 from ..__init__ import __version__
-from ..core.logger import create_diagnostics_logger, log_levels
-from ..core._core_execution_state import CoreExecutionState
+from ..core.logger import create_diagnostics_logger, log_levels, DiagnosticsLogger
+from ..core._core_execution_state import CoreExecutionState, get_private_core_state
 from ..core.execution_state import ExecutionState
 from ..core.chat_markdown_parser import parse_messages
 from ..core.command_interpreter import interpret_commands
@@ -18,18 +22,21 @@ from ..core.command_message import flatten_message_content, Message
 from ..core.load_configuration import load_config_file, default_load_config_files
 from .start_template import get_start_template
 
-# command line args ----------------------------------------------------------
+class ExitStatus(Enum):
+    SUCCESS = 0
+    FAILURE = 1
 
-argument_parser = None
+# command line args ----------------------------------------------------------
 
 def make_argument_parser() -> argparse.ArgumentParser:
     # create and initialize an ArgumentParser
     result = argparse.ArgumentParser(prog="prapti", description="Prapti markdown conversations")
     result.add_argument('--version', action='version', version=f"%(prog)s {__version__}")
-    result.add_argument("--dry-run", help="prepare the API request then bail", action="store_true")
+    result.add_argument("--dry-run", help="prepare the LLM API request then bail", action="store_true")
     result.add_argument("--halt-on-error", help="halt if errors are encountered, do not attempt error recovery", action="store_true")
     result.add_argument("--no-default-config", help="disable default config file search", action="store_true")
     result.add_argument("--config-file", help="specify additional config file(s)", required=False, default=[], action="append")
+    result.add_argument("--show-output", help="stream LLM output to standard output (in addition to updating file)", action="store_true")
 
     log_level_choices = [level.lower() for level in log_levels]
     result.add_argument("--log-level", help="specify the minimum level of log messages to be printed", choices=log_level_choices, required=False, default="info")
@@ -38,16 +45,21 @@ def make_argument_parser() -> argparse.ArgumentParser:
     result.add_argument("filename", help="the current markdown conversation file")
     return result
 
+argument_parser = make_argument_parser()
+
 # message sequence helpers ---------------------------------------------------
 
 def find_final_prompt_message(messages: list[Message]) -> Message|None:
-    """a prompt message is a message that will form part of the prompt. it is not hidden or disabled"""
+    """Returns the last message that forms part of the prompt and is not
+    hidden or disabled, or None if no such message exists."""
     try:
         return next(msg for msg in reversed(messages) if msg.is_enabled and msg.role in ("system", "user", "assistant", "prompt"))
     except StopIteration: # next() found no viable final message
         return None
 
 def find_final_user_message(messages: list[Message]) -> Message|None:
+    """Returns the last message with the role 'user' (whether or not disabled),
+    or None if no such message exists."""
     try:
         return next(msg for msg in reversed(messages) if msg.role == "user")
     except StopIteration: # next() found no viable final message
@@ -75,6 +87,8 @@ class TrailingLinesAnalysis:
     trailing_blank_line_count: int
 
 def analyze_trailing_lines(lines: list[str]) -> TrailingLinesAnalysis:
+    """Analyzes the trailing lines of a file to determine whether the file ends with a newline
+    and the number of trailing blank lines."""
     if not lines:
         has_no_lines = True
         final_line_has_newline = False
@@ -92,12 +106,15 @@ def analyze_trailing_lines(lines: list[str]) -> TrailingLinesAnalysis:
         final_line_has_newline=final_line_has_newline,
         trailing_blank_line_count=trailing_blank_line_count)
 
-class OutputFile:
-    def __init__(self, file: TextIO, lines_analysis: TrailingLinesAnalysis):
-        self.file: TextIO = file
+class OutputFormatter:
+    """Formats messages for text output, taking into account the current trailing whitespace
+    at the end of the file."""
+
+    def __init__(self, lines_analysis: TrailingLinesAnalysis):
+        assert lines_analysis is not None
         self.lines_analysis: TrailingLinesAnalysis = lines_analysis
 
-    def write_message(self, m: Message):
+    async def format_message(self, m: Message, log: DiagnosticsLogger) -> AsyncGenerator[str, None]:
         if m.role == "completion": # raw completion. retain all data without formatting/inserting extra newlines
             if m.content:
                 assert len(m.content) == 1 and isinstance(m.content[0], str), "prapti.main: expected flattened message content"
@@ -105,11 +122,31 @@ class OutputFile:
             else:
                 content = ""
 
+            content_yielded = False
+
             if content:
-                self.file.write(content)
-                self.lines_analysis = analyze_trailing_lines(content.splitlines(keepends=True))
+                yield content
+                content_yielded = True
+
+            if m.async_content is not None:
+                try:
+                    async for text in m.async_content:
+                        if not text: # ignore empty spans
+                            continue
+                        m.content.append(text)
+                        yield text
+                        content_yielded = True
+                except Exception as ex:
+                    log.error("async-content-exception", f"response ended unexpectedly. responder emitted exception while streaming asynchronous message content: {repr(ex)}")
+                    log.logger.debug(ex, exc_info=True)
+
+            if m.content:
+                m.content = ["".join(m.content)] # flatten sync content after appending async content
+
+            if content_yielded:
+                self.lines_analysis = analyze_trailing_lines(m.content[0].splitlines(keepends=True))
             else:
-                # no content. don't output anything. trailing lines analysis remains unaltered
+                # no content yielded. trailing lines analysis remains unaltered
                 pass
         else:
             # append newlines before appending message heading:
@@ -117,11 +154,11 @@ class OutputFile:
             # 1. the message heading appears at the start of a line
             # 2. the heading is preceeded by a blank line, or the start of file
 
+            add_newline_count = 0
             if self.lines_analysis.has_no_lines:
-                pass # it's ok to insert a heading on the first line of an empty file
+                pass
+                # it's ok to insert a heading on the first line of an empty file
             else:
-                add_newline_count = 0
-
                 # by definition (see above), a final line with no newline contains content,
                 # and since we want our heading to start at the start of a line, we cannot
                 # append our heading to the current final line, so append a newline.
@@ -133,49 +170,88 @@ class OutputFile:
                 # multiple existing blank lines, but in that case don't want to add any additional newlines
                 add_newline_count += max(0, 1 - self.lines_analysis.trailing_blank_line_count)
 
-                if add_newline_count > 0:
-                    self.file.write("\n" * add_newline_count)
-
+            newlines = "\n" * add_newline_count
             role_and_name = (m.role + "/" + m.name) if m.name else m.role
-            self.file.write(f"### {'' if m.is_enabled else '//'}@{role_and_name}:\n")
+            yield f"{newlines}### {'' if m.is_enabled else '//'}@{role_and_name}:\n"
 
+            # apply our own formatting to message content. in effect, the content is stripped
+            # of leading and trailing whitespace and then a single leading and trailing newline
+            # is added; as if `yield f"\n{content.strip()}\n"` were executed, but taking
+            # async content into account. if the message has no content, a single newline is output.
+
+            # in addition, async content is appended to message synchronous content.
+            # (without any of the above whitespace handling).
+
+            content_yielded = False
+            trailing_ws = "" # hold back trailing whitespace until we know there is more content
+
+            # output synchronous content
             if m.content:
-                # strip whitespace from start and end of message and apply our own formatting
                 assert len(m.content) == 1 and isinstance(m.content[0], str), "prapti.main: expected flattened message content"
-                content = "".join(m.content).strip()
-            else:
-                content = ""
+                content = "".join(m.content)
+                lcontent = content.lstrip()
+                if lcontent:
+                    lrcontent = lcontent.rstrip()
+                    yield "\n" + lrcontent
+                    content_yielded = True
+                    trailing_ws = lcontent[len(lrcontent):]
 
-            if content:
-                self.file.write(f"\n{content}\n")
+            # process and output asynchronous content
+            if m.async_content is not None:
+                try:
+                    async for text in m.async_content:
+                        if not text: # ignore empty spans
+                            continue
+                        m.content.append(text)
+
+                        if content_yielded:
+                            # retain leading whitespace within content
+                            rtext = text.rstrip()
+                            yield trailing_ws + rtext
+                            trailing_ws = text[len(rtext):]
+                        else:
+                            # strip leading whitespace at start of content
+                            ltext = text.lstrip()
+                            if ltext:
+                                lrtext = ltext.rstrip()
+                                yield "\n" + lrtext # no content yielded yet, leading newline
+                                content_yielded = True
+                                trailing_ws = ltext[len(lrtext):]
+                except Exception as ex:
+                    log.error("async-content-exception", f"response ended unexpectedly. responder emitted exception while streaming asynchronous message content: {repr(ex)}")
+                    log.logger.debug(ex, exc_info=True)
+
+                if m.content:
+                    m.content = ["".join(m.content)] # flatten sync content after appending async content
+
+            if content_yielded:
+                yield "\n" # single newline at end of content
                 self.lines_analysis = TrailingLinesAnalysis(
                     has_no_lines = False,
                     final_line_has_newline = True,
                     trailing_blank_line_count = 0)
             else:
-                self.file.write("\n") # one blank line between the message heading and the content, which in this case is empty
+                yield "\n" # one blank line between the message heading and the content, which in this case is empty
                 self.lines_analysis = TrailingLinesAnalysis(
                     has_no_lines = False,
                     final_line_has_newline = True,
                     trailing_blank_line_count = 1)
 
-    def write_messages(self, messages: list[Message]):
-        for m in messages:
-            self.write_message(m)
-
-    def flush(self):
-        self.file.flush()
-
-    def close(self):
-        self.file.close()
-
 # ----------------------------------------------------------------------------
 
-def main(argv: Sequence[str] | None = None, test_exfil: dict|None = None) -> int:
-    global argument_parser
-    if not argument_parser:
-        argument_parser = make_argument_parser()
+@dataclass
+class RunState:
+    completed: bool
+    result_code: int|None = None
+    state: ExecutionState|None = None
+    file: TextIO|None = None
+    lines_analysis: TrailingLinesAnalysis|None = None
+    early_output: list[str|Message] = field(default_factory=list)
+    user_response_prompt_message: Message|None = None
+    show_output: bool = False
 
+def run_phase_1(argv: Sequence[str] | None = None, test_exfil: dict|None = None, input_lines: list[str]|None = None) -> RunState:
+    """synchronous execution phase: parse input, run commands prepare prompt."""
     if not argv:
         argv = sys.argv # use sys.argv if None is passed
     state_argv = list(argv) # capture a copy
@@ -184,8 +260,8 @@ def main(argv: Sequence[str] | None = None, test_exfil: dict|None = None) -> int
 
     log_level = log_levels.get(command_line_args.log_level.upper(), None)
     if not log_level:
-        print(f"error: '{command_line_args.log_level}' is not a valid log level")
-        return 1
+        print(f"error: '{command_line_args.log_level}' is not a valid log level", file=sys.stderr, flush=True)
+        return RunState(completed=True, result_code=ExitStatus.FAILURE.value)
 
     # construct execution state
     state = ExecutionState(prapti_version=__version__, argv=state_argv, log=create_diagnostics_logger(initial_level=log_level), input_file_path=pathlib.Path(command_line_args.filename))
@@ -199,85 +275,223 @@ def main(argv: Sequence[str] | None = None, test_exfil: dict|None = None) -> int
     state.test_exfil["state"] = state
 
     # load config files
+    state.log.info("loading-config", "loading configuration files...", state.input_file_path)
+
     if not command_line_args.no_default_config:
         default_load_config_files(state)
 
     for config_path in map(pathlib.Path, command_line_args.config_file):
         load_config_file(config_path, state)
 
-    # process input file, generate response
-    with open(state.input_file_path, "rt+", encoding="utf-8") as file:
+    # process input file
+    state.log.info("processing-input", "processing input...", state.input_file_path)
+
+    file = None
+    if input_lines is None:
         state.log.info("loading-input", "loading input file", state.input_file_path)
-        lines = file.readlines()
-        # early-out if the input file is effectively empty
-        if not lines or all(not line.strip() for line in lines): # if file is effectively empty
-            state.log.info("empty-input", "here's the start template. start writing.", state.input_file_path)
-            file.write(get_start_template(state))
-            return 0
 
-        input_messages: list[Message] = parse_messages(lines, state.input_file_path)
-        interpret_commands(input_messages, state, is_final_sequence=True)
-        state.message_sequence += input_messages
+        try:
+            file = open(state.input_file_path, "rt+", encoding="utf-8")
+        except OSError as e:
+            state.log.info("error-opening-input", f"could not open input file '{state.input_file_path}': {e}")
+            return RunState(completed=True, state=state, result_code=ExitStatus.FAILURE.value)
 
-        emitted_messages = flatten_message_content(state.message_sequence)
+        input_lines = file.readlines()
 
-        output_file = OutputFile(file=file, lines_analysis=analyze_trailing_lines(lines))
+    lines_analysis=analyze_trailing_lines(input_lines)
 
-        final_user_message = find_final_user_message(state.message_sequence)
-        user_name = final_user_message.name if final_user_message else None
-        user_response_prompt_message = Message(role="user", name=user_name, content=[]) # i.e. ### @user/name:
+    # early-out if the input file is effectively empty
+    if not input_lines or all(not line.strip() for line in input_lines): # if file is effectively empty
+        state.log.info("empty-input", "here's the start template. start writing.", state.input_file_path)
+        return RunState(completed=True, state=state, result_code=ExitStatus.SUCCESS.value, file=file, lines_analysis=lines_analysis, early_output=[get_start_template(state)], show_output=command_line_args.show_output)
 
-        # early-out with messages generated by commands
-        if emitted_messages:
-            flatten_message_content(emitted_messages)
-            output_file.write_messages(emitted_messages)
-            output_file.write_message(user_response_prompt_message)
-            return 0
+    input_messages: list[Message] = parse_messages(input_lines, state.input_file_path)
+    interpret_commands(input_messages, state, is_final_sequence=True)
+    state.message_sequence += input_messages
 
-        # NOTE: check for empty prompt *after* evaluating commands and flattening messages that could extend the message text
-        final_prompt_message = find_final_prompt_message(state.message_sequence)
-        if not final_prompt_message:
-            # early-out if no viable prompt message supplied
-            state.log.info("absent-prompt", "no non-hidden non-disabled messages found. write something.", state.input_file_path)
-            output_file.write_message(user_response_prompt_message)
-            return 0
+    emitted_messages = flatten_message_content(state.message_sequence)
 
-        # early-out if there is a final prompt, but it does not contain any text
-        # (i.e. assume that the user triggered execution before typing their question)
-        if final_prompt_message.content_is_empty():
-            state.log.info("empty-final-prompt", "final prompt is empty. write something.", final_prompt_message.source_loc)
-            return 0
+    final_user_message = find_final_user_message(state.message_sequence)
+    user_name = final_user_message.name if final_user_message else None
+    user_response_prompt_message = Message(role="user", name=user_name, content=[]) # i.e. ### @user/name:
 
-        if state.root_config.prapti.halt_on_error and (state.log.critical_count() > 0 or state.log.error_count() > 0):
-            state.log.error("error-halting", "halting due to errors.", state.input_file_path)
-            return 1
+    # early-out with messages generated by commands
+    if emitted_messages:
+        flatten_message_content(emitted_messages)
+        state.log.info("processing-input-done-early-output", "processing input done. output generated by command(s).", state.input_file_path)
+        return RunState(completed=True, state=state, result_code=ExitStatus.SUCCESS.value, file=file, lines_analysis=lines_analysis, early_output=emitted_messages + [user_response_prompt_message])
 
-        core_state.hooks_distributor.on_generating_response()
+    # NOTE: check for empty prompt *after* evaluating commands and flattening messages that could extend the message text
+    final_prompt_message = find_final_prompt_message(state.message_sequence)
+    if not final_prompt_message:
+        # early-out if no viable prompt message supplied
+        state.log.info("absent-prompt", "no non-hidden non-disabled messages found. write something.", state.input_file_path)
+        return RunState(completed=True, state=state, result_code=ExitStatus.SUCCESS.value, file=file, lines_analysis=lines_analysis, early_output=[user_response_prompt_message], show_output=command_line_args.show_output)
+
+    # early-out if there is a final prompt, but it does not contain any text
+    # (i.e. assume that the user triggered execution before typing their question)
+    if final_prompt_message.content_is_empty():
+        state.log.info("empty-final-prompt", "final prompt is empty. write something.", final_prompt_message.source_loc)
+        return RunState(completed=True, state=state, result_code=ExitStatus.SUCCESS.value)
+
+    if state.root_config.prapti.halt_on_error and (state.log.critical_count() > 0 or state.log.error_count() > 0):
+        state.log.error("error-halting", "halting due to errors.", state.input_file_path)
+        return RunState(completed=True, state=state, result_code=ExitStatus.FAILURE.value)
+
+    state.log.info("processing-input-done", "processing input done.", state.input_file_path)
+    return RunState(completed=False, state=state, file=file, lines_analysis=lines_analysis, user_response_prompt_message=user_response_prompt_message, show_output=command_line_args.show_output)
+
+async def format_early_output(items: list[Message|str], output_formatter: OutputFormatter, log: DiagnosticsLogger) -> str:
+    result = []
+    for item in items:
+        match(item):
+            case str():
+                result.append(item)
+            case Message():
+                async for text in output_formatter.format_message(item, log):
+                    result.append(text)
+    return "".join(result)
+
+@dataclass
+class EndOfOutputSentinel:
+    pass
+
+@dataclass
+class CompletionSentinel:
+    result_code: int
+
+async def run_phase_2(run_state: RunState, cancellation_token: CancellationToken) -> AsyncGenerator[str|EndOfOutputSentinel|CompletionSentinel, None]:
+    """asynchrononous execution phase: generate output, emit result code"""
+
+    if run_state.state is None:
+        # if no execution state was created there is no logger, so perform a best-effort cleanup
+        assert run_state.completed
+        assert run_state.result_code is not None
+        assert not run_state.early_output
+        yield EndOfOutputSentinel()
+        yield CompletionSentinel(result_code=run_state.result_code)
+        return
+
+    assert run_state.state is not None
+    state = run_state.state
+    core_state = get_private_core_state(state)
+    end_of_output_sentinel_yielded = False
+    result_code = ExitStatus.FAILURE.value
+    try:
+        if run_state.early_output or not run_state.completed:
+            # if there is early output, or there might be phase-2 output,
+            # phase-1 should have computed a lines_analysis
+            assert run_state.lines_analysis is not None
+
+        output_formatter = None
+
+        if run_state.early_output:
+            assert run_state.state is not None
+            assert run_state.lines_analysis is not None
+            output_formatter = OutputFormatter(lines_analysis=run_state.lines_analysis)
+            output_text = await format_early_output(run_state.early_output, output_formatter, run_state.state.log)
+            yield output_text
+
+        if run_state.completed:
+            assert run_state.result_code is not None
+            result_code=run_state.result_code
+            return
+
+        # end early-completion / early-output emission
+
+        if not output_formatter:
+            assert run_state.lines_analysis is not None
+            output_formatter = OutputFormatter(lines_analysis=run_state.lines_analysis)
 
         state.log.info("generating-responses", "generating response(s). please wait...", state.input_file_path)
 
-        # generate responses
+        core_state.hooks_distributor.on_generating_response()
+
         responder_name, responder_context = lookup_active_responder(state)
         if not responder_context:
             state.log.critical("active-responder-not-found", f"couldn't generate a response, sorry. the active responder '{responder_name}' was not found.", state.input_file_path)
-            return 1
-        if bool(responses := responder_context.responder.generate_responses(state.message_sequence, responder_context)):
-            state.responses = responses
-            output_file.write_messages(state.responses)
+            result_code = ExitStatus.FAILURE.value
+            return
 
-            if state.responses[-1].role not in ("completion", "prompt"):
-                # only prompt for next ### @user: input if we're in a user/assistant/user chat mode
-                output_file.write_message(user_response_prompt_message)
+        if cancellation_token.cancelled:
+            state.log.error("generate-responses-cancelled", "generating responses cancelled.", state.input_file_path)
+            result_code = ExitStatus.FAILURE.value
+            return
 
-            output_file.flush()
-            output_file.close() # ensure flush and close prior to calling on_response_completed
+        async_responses = responder_context.responder.generate_responses(state.message_sequence, cancellation_token, responder_context)
+
+        responses = []
+        async for message in async_responses:
+            responses.append(message)
+            async_text = output_formatter.format_message(message, state.log)
+            async for text in async_text:
+                yield text
+        state.responses = responses
+
+        if responses and responses[-1].role not in ("completion", "prompt") and run_state.user_response_prompt_message:
+            # only prompt for next ### @user: input if we're in a user/assistant/user chat mode
+            async_text = output_formatter.format_message(run_state.user_response_prompt_message, state.log)
+            async for text in async_text:
+                yield text
+
+        end_of_output_sentinel_yielded = True
+        yield EndOfOutputSentinel() # trigger/ensure flush and close prior to calling on_response_completed
+
+        if cancellation_token.cancelled:
+            state.log.error("generate-responses-cancelled", "generating responses cancelled.", state.input_file_path)
+
+        if state.responses:
             core_state.hooks_distributor.on_response_completed()
 
-            state.log.info("generating-responses-done", "done.", state.input_file_path)
+            state.log.info("generating-responses-done", "generating responses done.", state.input_file_path)
         else:
-            state.log.error("no-response", "no response generated, sorry.", state.input_file_path)
+            if not cancellation_token.cancelled:
+                state.log.error("no-response", "no response generated, sorry.", state.input_file_path)
 
-    if state.log.critical_count() == 0 and state.log.error_count() == 0:
-        return 0 # success
-    else:
-        return 1 # failure
+        if state.log.critical_count() == 0 and state.log.error_count() == 0:
+            result_code = ExitStatus.SUCCESS.value
+        else:
+            result_code = ExitStatus.FAILURE.value
+    except Exception as ex:
+        state.log.error("unhandled-exception", f"generation halted unexpectedly. an unhandled exception occurred: {repr(ex)}", state.input_file_path)
+        state.log.logger.error(ex, exc_info=True)
+    finally:
+        if not end_of_output_sentinel_yielded:
+            yield EndOfOutputSentinel()
+        yield CompletionSentinel(result_code=result_code)
+
+async def async_main_run_phase_2(run_state: RunState) -> int:
+    """run asynchronous response generation, write output to file and console, return result code"""
+    has_output = False
+    async_output = run_phase_2(run_state, CancellationToken())
+    async for item in async_output:
+        match item:
+            case str():
+                assert run_state.file is not None
+                assert run_state.lines_analysis is not None
+
+                text = item
+                run_state.file.write(text)
+
+                if run_state.show_output:
+                    if not has_output:
+                        print(">>>>>>>>\n", end="", flush=False)
+                    print(text, end="", flush=True)
+                    has_output = True
+
+            case EndOfOutputSentinel():
+                if run_state.file:
+                    run_state.file.flush()
+                    run_state.file.close() # ensure flush and close prior to calling on_response_completed
+
+                if run_state.show_output:
+                    note = "" if has_output else "(no output)"
+                    print(f"{note}\n<<<<<<<<\n", end="", flush=True)
+
+            case CompletionSentinel():
+                return item.result_code
+    assert False, "run_phase_2 did not yield CompletionSentinel"
+
+def main(argv: Sequence[str] | None = None, test_exfil: dict|None = None) -> int:
+    run_state = run_phase_1(argv, test_exfil)
+    return asyncio.run(async_main_run_phase_2(run_state))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
     "requests >= 2.28.1",
     "openai >= 0.27.6",
     "tiktoken >= 0.4.0",
-    "gpt4all >= 1.0.2"
+    "gpt4all >= 1.0.2",
+    "cancel_token >= 0.1.6"
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Change Responder's generate_responses() interface to return async streams of messages. Extend Message interface to include an async_content field for streaming async message content. Rework all responders, and command line tool to implement async responses. Added the --show-output command line option to preview output (including streaming output) in the terminal. Added global vars.stream variable to control streaming.

Note: this is a large piece in preparation for merging the language server protocol server which can stream responses directly into the document.