### PR TITLE
general message scope prefix mechanism for plugin log messages

### DIFF
--- a/prapti/core/action.py
+++ b/prapti/core/action.py
@@ -27,6 +27,7 @@ class Action:
     function: Callable[[str, str, ActionContext], None|str|Message]
     exclamation_only: bool = False # !-only commands may only appear in markdown with the ! prefix
     plugin_config: Any|None = None
+    plugin_log: DiagnosticsLogger|None = None
 
 class ActionNamespace:
     def __init__(self):
@@ -59,10 +60,11 @@ class ActionNamespace:
             return func
         return decorator
 
-    def set_plugin_config(self, plugin_config: Any):
+    def set_plugin_config_and_log(self, plugin_config: Any, plugin_log: DiagnosticsLogger):
         for _,v in self._actions.items():
             for action in v:
                 action.plugin_config = plugin_config
+                action.plugin_log = plugin_log
 
     def lookup_action(self, name: str) -> list[Action]:
         name_components = name.split('.')

--- a/prapti/core/command_interpreter.py
+++ b/prapti/core/command_interpreter.py
@@ -30,7 +30,8 @@ def run_action(has_exclamation: bool, action_name: str, raw_args: str, source_lo
                 state.log.error("excl-only-action-without-excl", f"didn't run action '{action_name}'. action is !-only but written without a '!'", source_loc)
                 return None
 
-            context = ActionContext(state=state, root_config=state.root_config, plugin_config=action.plugin_config, source_loc=source_loc, log=state.log)
+            action_log = action.plugin_log if action.plugin_log else state.log
+            context = ActionContext(state=state, root_config=state.root_config, plugin_config=action.plugin_config, source_loc=source_loc, log=action_log)
             return action.function(action_name, raw_args, context)
         case _:
             alternatives = _join_alternatives([action.qualified_name for action in matches])

--- a/prapti/core/execution_state.py
+++ b/prapti/core/execution_state.py
@@ -2,7 +2,7 @@ from typing import Any
 from dataclasses import dataclass, field
 import pathlib
 
-from .logger import DiagnosticsLogger
+from .logger import RootDiagnosticsLogger
 from .configuration import RootConfiguration
 from .command_message import Message
 
@@ -14,7 +14,7 @@ class ExecutionState:
     """
     prapti_version: str
     argv: list[str]
-    log: DiagnosticsLogger
+    log: RootDiagnosticsLogger
     input_file_path: pathlib.Path
     user_prapti_config_dir: pathlib.Path|None = None # typically ~/.config/prapti but other locations are possible
     prapticonfig_dirs: list[pathlib.Path] = field(default_factory=list)

--- a/prapti/core/load_configuration.py
+++ b/prapti/core/load_configuration.py
@@ -36,7 +36,7 @@ def load_config_file(config_path: pathlib.Path, state: ExecutionState) -> bool:
             parse_messages_and_interpret_commands(config_file_lines, config_path, state)
         except Exception as ex:
             state.log.error("config-file-exception", f"exception while loading configuration file: {repr(ex)}", config_path)
-            state.log.logger.debug(ex, exc_info=True)
+            state.log.debug_exception(ex)
         return True
     return False
 
@@ -117,7 +117,7 @@ def locate_and_parse_in_tree_prapticonfig_md_files(state: ExecutionState) -> tup
                 message_sequence = parse_messages(config_file_lines, config_path)
             except Exception as ex:
                 state.log.error("read-config-file-exception", f"exception while reading configuration file: {repr(ex)}", config_path)
-                state.log.logger.debug(ex, exc_info=True)
+                state.log.debug_exception(ex)
         prapticonfig_mds.append((config_path, message_sequence))
         if message_sequence and is_config_root(message_sequence): # stop iterating once we hit a config file with `%config_root = true`
             break
@@ -138,7 +138,7 @@ def execute_in_tree_prapticonfig_md_files(prapticonfig_mds: list[tuple[pathlib.P
                 state.root_config.prapti.config_root = False
             except Exception as ex:
                 state.log.error("load-config-file-exception", f"exception while loading configuration file: {repr(ex)}", config_path)
-                state.log.logger.debug(ex, exc_info=True)
+                state.log.debug_exception(ex)
 
 def default_load_config_files(state: ExecutionState):
     """Default configuration loading. Load configuration from:

--- a/prapti/plugins/capture_everything.py
+++ b/prapti/plugins/capture_everything.py
@@ -112,7 +112,7 @@ class CaptureEverythingHooks(Hooks):
             return
 
         if not self._capture_file_name:
-            context.log.error("bad-capture-file-name", "prapti.capture_everything: skipping capture. no capture file name.")
+            context.log.error("bad-capture-file-name", "skipping capture. no capture file name.")
             return
 
         self._end_time = datetime.now()
@@ -145,9 +145,9 @@ class CaptureEverythingHooks(Hooks):
                 with capture_file_path.open("w") as file:
                     json.dump(self._capture_data, file)
             else:
-                context.log.error("bad-capture-dir", f"prapti.capture_everything: skipping capture. capture directory '{capture_dir}' does not exist or is not a directory")
+                context.log.error("bad-capture-dir", f"skipping capture. capture directory '{capture_dir}' does not exist or is not a directory")
         else:
-            context.log.warning("capture-dir-not-set", "prapti.capture_everything: plugin is loaded but capture directory has not been set. add '% prapti.plugins.capture_everything.capture_dir = ... to your config.")
+            context.log.warning("capture-dir-not-set", "plugin is loaded but capture directory has not been set. add '% prapti.plugins.capture_everything.capture_dir = ... to your config.")
 
 class CaptureEverythingPlugin(Plugin):
     def __init__(self):

--- a/prapti/plugins/experimental_agents.py
+++ b/prapti/plugins/experimental_agents.py
@@ -187,14 +187,14 @@ class AgentsResponder(Responder):
             if hasattr(context.root_config.responders, agent_name): # a responder exists with /name/
                 result.add(agent_name)
             else:
-                context.log.error("no-rexponder-for-agent", f"prapti.experimental.agents: discussion_group specifies agent '{agent_name}' but no responder exists with that name.")
+                context.log.error("no-rexponder-for-agent", f"discussion_group specifies agent '{agent_name}' but no responder exists with that name.")
         return result
 
     async def _async_response_generator(self, input_: list[Message], cancellation_token: CancellationToken, context: ResponderContext) -> AsyncGenerator[Message, None]:
         config: AgentsResponderConfiguration = context.responder_config
-        context.log.debug(f"prapti.experimental.agents: input: {config = }", context.state.input_file_path)
+        context.log.debug(f"input: {config = }", context.state.input_file_path)
         config = resolve_var_refs(config, context.root_config, context.log)
-        context.log.debug(f"prapti.experimental.agents: resolved: {config = }", context.state.input_file_path)
+        context.log.debug(f"resolved: {config = }", context.state.input_file_path)
 
         message_sequence = copy.deepcopy(input_)
 
@@ -202,7 +202,7 @@ class AgentsResponder(Responder):
         participants: set[str] = self._valid_discussion_group_participants(plugin_config, context)
 
         if not participants:
-            context.log.warning("agents-no-participants", "prapti.experimental.agents: could not continue discussion. no valid participants specified in discussion_group.")
+            context.log.warning("agents-no-participants", "could not continue discussion. no valid participants specified in discussion_group.")
             return
 
         all_pending_at_mentions: set[str] = self._compute_pending_at_mentions(message_sequence, context) # all @-mentions, not limited to participants or even agents/responders

--- a/prapti/plugins/experimental_gitlog.py
+++ b/prapti/plugins/experimental_gitlog.py
@@ -112,7 +112,7 @@ class GitlogHooks(Hooks):
         """
         log = context.log
         log.debug("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv")
-        log.debug("prapti.experimental.gitlog: on_plugin_loaded")
+        log.debug("on_plugin_loaded")
         log.debug(f"{context.state.input_file_path = }")
         file_path = context.state.input_file_path.resolve()
         main_worktree_dir = file_path.parent
@@ -214,7 +214,7 @@ class GitlogHooks(Hooks):
         """
         log = context.log
         log.debug("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv")
-        log.debug("prapti.experimental.gitlog: on_response_completed")
+        log.debug("on_response_completed")
         log.debug(f"{context.state.input_file_path = }")
 
         main_worktree_dir = context.state.input_file_path.resolve().parent

--- a/prapti/plugins/prapti_test_responder.py
+++ b/prapti/plugins/prapti_test_responder.py
@@ -41,17 +41,17 @@ class TestResponder(Responder):
     async def _async_response_generator(self, input_: list[Message], cancellation_token: CancellationToken, context: ResponderContext) -> AsyncGenerator[Message, None]:
         plugin_config: TestResponderConfiguration = context.plugin_config
         assert plugin_config is not None
-        context.log.debug(f"prapti.test.test_responder: input: {plugin_config = }", context.state.input_file_path)
+        context.log.debug(f"input: {plugin_config = }", context.state.input_file_path)
         plugin_config = resolve_var_refs(plugin_config, context.root_config, context.log)
-        context.log.debug(f"prapti.test.test_responder: resolved: {plugin_config = }", context.state.input_file_path)
+        context.log.debug(f"resolved: {plugin_config = }", context.state.input_file_path)
 
         context.state.test_exfil["test_responder_resolved_plugin_config"] = plugin_config
 
         responder_config: TestResponderConfiguration = context.responder_config
         assert responder_config is not None
-        context.log.debug(f"prapti.test.test_responder: input: {responder_config = }", context.state.input_file_path)
+        context.log.debug(f"input: {responder_config = }", context.state.input_file_path)
         responder_config = resolve_var_refs(responder_config, context.root_config, context.log)
-        context.log.debug(f"prapti.test.test_responder: resolved: {responder_config = }", context.state.input_file_path)
+        context.log.debug(f"resolved: {responder_config = }", context.state.input_file_path)
 
         context.state.test_exfil["test_responder_resolved_responder_config"] = responder_config
 

--- a/prapti/tool/start_template.py
+++ b/prapti/tool/start_template.py
@@ -33,6 +33,6 @@ def get_start_template(state: ExecutionState) -> str:
         result = start_template_path.read_text(encoding="utf-8")
     except Exception as ex:
         state.log.error("start-template-exception", f"exception while reading start template: {repr(ex)}", start_template_path)
-        state.log.logger.debug(ex, exc_info=True)
+        state.log.debug_exception(ex)
         result = FALLBACK_START_TEMPLATE
     return result

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -7,8 +7,8 @@ import prapti.core.logger
 from prapti.core.source_location import SourceLocation
 
 @pytest.fixture(name="log", scope="function")
-def fixture_log() -> prapti.core.logger.DiagnosticsLogger:
-    return prapti.core.logger.create_diagnostics_logger()
+def fixture_log() -> prapti.core.logger.RootDiagnosticsLogger:
+    return prapti.core.logger.create_root_diagnostics_logger()
 
 def test_logger_check_caplog(caplog, log):
     """emit all message levels. check pytest caplog fixture behavior"""
@@ -130,6 +130,10 @@ def test_logger_smoke(caplog, log):
     log.detail("detail without message id")
     log.debug("debug dump without message id")
 
+    # log with scope qualifiers
+    scoped_log = prapti.core.logger.ScopedDiagnosticsLogger(log, ("scope-1", "scope-2"))
+    scoped_log.info("scoped-info-1", "info message")
+
     assert log.critical_count() == 2
     assert log.error_count() == 2
     assert log.warning_count() == 1
@@ -149,6 +153,7 @@ def test_logger_smoke(caplog, log):
         ("prapti", prapti.core.logger.DETAIL, "detail: [detail-1]: detail with message id"),
         ("prapti", prapti.core.logger.DETAIL, "detail: detail without message id"),
         ("prapti", logging.DEBUG, "debug: debug dump without message id"),
+        ("prapti", logging.INFO, "info: [scoped-info-1]: scope-1: scope-2: info message"),
     ]
     # caplog captures logging records prior to formatting. In order to test our expectations
     # regarding *formatted* output, we manually format the emitted records as part of the test.


### PR DESCRIPTION
replace hard-coded plugin name prefixes in plugin log messages with a general message scope prefix mechanism implemented by the ScopedDiagnosticsLogger decorator. now when plugins use context.log.info(...) etc, their messages will automatically be prefixed with their plugin name.